### PR TITLE
Fixed a missing ChibiOS file 

### DIFF
--- a/cmake/ChibiOS16_HAL.cmake
+++ b/cmake/ChibiOS16_HAL.cmake
@@ -19,6 +19,10 @@ FOREACH(module ${CHIBIOS_HAL_MODULES})
   IF(${module} STREQUAL mmcsd)
     SET(CHIBIOS_${module}_SOURCES hal_mmcsd.c)
   ENDIF()
+
+  IF(${module} STREQUAL serial_usb)
+    SET(CHIBIOS_${module}_SOURCES ${CHIBIOS_${module}_SOURCES} hal_buffers.c)
+  ENDIF()
 ENDFOREACH()
 
 FOREACH(module ${CHIBIOS_HAL_LIB_MODULES})


### PR DESCRIPTION
Fixed a missing ChibiOS file causing link errors when using serial_usb module.