### PR TITLE
Support LL library

### DIFF
--- a/cmake/FindSTM32HAL.cmake
+++ b/cmake/FindSTM32HAL.cmake
@@ -13,13 +13,6 @@ IF(STM32_FAMILY STREQUAL "F0")
 
     SET(HAL_PREFIX stm32f0xx_)
 
-    SET(HAL_HEADERS
-        stm32f0xx_hal.h
-        stm32f0xx_hal_def.h
-    )
-    SET(HAL_SRCS
-        stm32f0xx_hal.c
-    )
 ELSEIF(STM32_FAMILY STREQUAL "F1")
     SET(HAL_COMPONENTS adc can cec cortex crc dac dma eth flash gpio hcd i2c
                        i2s irda iwdg nand nor pccard pcd pwr rcc rtc sd smartcard
@@ -35,13 +28,6 @@ ELSEIF(STM32_FAMILY STREQUAL "F1")
 
     SET(HAL_PREFIX stm32f1xx_)
 
-    SET(HAL_HEADERS
-        stm32f1xx_hal.h
-        stm32f1xx_hal_def.h
-    )
-    SET(HAL_SRCS
-        stm32f1xx_hal.c
-    )
 ELSEIF(STM32_FAMILY STREQUAL "F2")
     SET(HAL_COMPONENTS adc can cortex crc cryp dac dcmi dma eth flash
                        gpio hash hcd i2c i2s irda iwdg nand nor pccard
@@ -58,14 +44,6 @@ ELSEIF(STM32_FAMILY STREQUAL "F2")
 
     SET(HAL_PREFIX stm32f2xx_)
 
-    SET(HAL_HEADERS
-        stm32f2xx_hal.h
-        stm32f2xx_hal_def.h
-    )
-
-    SET(HAL_SRCS
-        stm32f2xx_hal.c
-    )
 ELSEIF(STM32_FAMILY STREQUAL "F3")
     SET(HAL_COMPONENTS adc can cec comp cortex crc dac dma flash gpio i2c i2s
                        irda nand nor opamp pccard pcd pwr rcc rtc sdadc
@@ -78,14 +56,6 @@ ELSEIF(STM32_FAMILY STREQUAL "F3")
 
     SET(HAL_PREFIX stm32f3xx_)
 
-    SET(HAL_HEADERS
-        stm32f3xx_hal.h
-        stm32f3xx_hal_def.h
-    )
-
-    SET(HAL_SRCS
-        stm32f3xx_hal.c
-    )
 ELSEIF(STM32_FAMILY STREQUAL "F4")
     SET(HAL_COMPONENTS adc can cec cortex crc cryp dac dcmi dma dma2d eth flash
                        flash_ramfunc fmpi2c gpio hash hcd i2c i2s irda iwdg ltdc
@@ -104,14 +74,6 @@ ELSEIF(STM32_FAMILY STREQUAL "F4")
 
     SET(HAL_PREFIX stm32f4xx_)
 
-    SET(HAL_HEADERS
-        stm32f4xx_hal.h
-        stm32f4xx_hal_def.h
-    )
-
-    SET(HAL_SRCS
-        stm32f4xx_hal.c
-    )
 ELSEIF(STM32_FAMILY STREQUAL "F7")
     SET(HAL_COMPONENTS adc can cec cortex crc cryp dac dcmi dma dma2d eth flash
                        gpio hash hcd i2c i2s irda iwdg lptim ltdc nand nor pcd
@@ -129,14 +91,6 @@ ELSEIF(STM32_FAMILY STREQUAL "F7")
 
     SET(HAL_PREFIX stm32f7xx_)
 
-    SET(HAL_HEADERS
-        stm32f7xx_hal.h
-        stm32f7xx_hal_def.h
-    )
-
-    SET(HAL_SRCS
-        stm32f7xx_hal.c
-    )
 ELSEIF(STM32_FAMILY STREQUAL "L0")
     SET(HAL_COMPONENTS adc comp cortex crc crs cryp dac dma exti firewall flash gpio i2c
                        i2s irda iwdg lcd lptim lpuart pcd pwr rcc rng rtc smartcard
@@ -152,16 +106,9 @@ ELSEIF(STM32_FAMILY STREQUAL "L0")
 
     SET(HAL_PREFIX stm32l0xx_)
 
-    SET(HAL_HEADERS
-        stm32l0xx_hal.h
-        stm32l0xx_hal_def.h
-    )
-    SET(HAL_SRCS
-        stm32l0xx_hal.c
-    )
 ELSEIF(STM32_FAMILY STREQUAL "L4")
     SET(HAL_COMPONENTS adc can comp cortex crc cryp dac dcmi dfsdm dma dma2d dsi 
-                       firewall flash flash_ramfunc gfxmmu gpio hash hcd i2c irda iwdg 
+                       firewall flash flash_ramfunc gfxmmu gpio hash hcd i2c irda iwdg
                        lcd lptim ltdc nand nor opamp ospi pcd pwr qspi rcc rng rtc sai
                        sd smartcard smbus spi sram swpmi tim tsc uart usart wwdg)
 
@@ -178,16 +125,16 @@ ELSEIF(STM32_FAMILY STREQUAL "L4")
 
     SET(HAL_PREFIX stm32l4xx_)
 
-    SET(HAL_HEADERS
-        stm32l4xx_hal.h
-        stm32l4xx_hal_def.h
-    )
-
-    SET(HAL_SRCS
-        stm32l4xx_hal.c
-    )    
 ENDIF()
 
+SET(HAL_HEADERS
+	${HAL_PREFIX}hal.h
+	${HAL_PREFIX}hal_def.h
+)
+
+SET(HAL_SRCS
+	${HAL_PREFIX}hal.c
+)
 IF(NOT STM32HAL_FIND_COMPONENTS)
     SET(STM32HAL_FIND_COMPONENTS ${HAL_COMPONENTS})
     MESSAGE(STATUS "No STM32HAL components selected, using all: ${STM32HAL_FIND_COMPONENTS}")

--- a/cmake/FindSTM32HAL.cmake
+++ b/cmake/FindSTM32HAL.cmake
@@ -8,9 +8,6 @@ IF(STM32_FAMILY STREQUAL "F0")
     # Components that have _ex sources
     SET(HAL_EX_COMPONENTS adc crc dac flash i2c pcd pwr rcc rtc smartcard spi tim uart)
 
-    # Components that have ll_ in names instead of hal_
-    SET(HAL_LL_COMPONENTS "")
-
     SET(HAL_PREFIX stm32f0xx_)
 
 ELSEIF(STM32_FAMILY STREQUAL "F1")
@@ -22,9 +19,6 @@ ELSEIF(STM32_FAMILY STREQUAL "F1")
 
     # Components that have _ex sources
     SET(HAL_EX_COMPONENTS adc dac flash gpio pcd rcc rtc tim)
-
-    # Components that have ll_ in names instead of hal_
-    SET(HAL_LL_COMPONENTS fsmc sdmmc usb)
 
     SET(HAL_PREFIX stm32f1xx_)
 
@@ -38,9 +32,6 @@ ELSEIF(STM32_FAMILY STREQUAL "F2")
 
     # Components that have _ex sources
     SET(HAL_EX_COMPONENTS adc dac dma flash pwr rcc rtc tim)
-
-    # Components that have ll_ in names instead of hal_
-    SET(HAL_LL_COMPONENTS fsmc sdmmc usb)
 
     SET(HAL_PREFIX stm32f2xx_)
 
@@ -69,9 +60,6 @@ ELSEIF(STM32_FAMILY STREQUAL "F4")
     SET(HAL_EX_COMPONENTS adc cryp dac dcmi dma flash fmpi2c hash i2c i2s pcd
                           pwr rcc rtc sai tim)
 
-    # Components that have ll_ in names instead of hal_
-    SET(HAL_LL_COMPONENTS fmc fsmc sdmmc usb)
-
     SET(HAL_PREFIX stm32f4xx_)
 
 ELSEIF(STM32_FAMILY STREQUAL "F7")
@@ -86,9 +74,6 @@ ELSEIF(STM32_FAMILY STREQUAL "F7")
     SET(HAL_EX_COMPONENTS adc crc cryp dac dcmi dma flash hash i2c pcd
                           pwr rcc rtc sai tim)
 
-    # Components that have ll_ in names instead of hal_
-    SET(HAL_LL_COMPONENTS fmc sdmmc usb)
-
     SET(HAL_PREFIX stm32f7xx_)
 
 ELSEIF(STM32_FAMILY STREQUAL "L0")
@@ -100,9 +85,6 @@ ELSEIF(STM32_FAMILY STREQUAL "L0")
 
     # Components that have _ex sources
     SET(HAL_EX_COMPONENTS adc comp crc cryp dac flash i2c pcd pwr rcc rtc smartcard tim uart usart)
-
-    # Components that have ll_ in names instead of hal_
-    SET(HAL_LL_COMPONENTS crs exti lpuart utils)
 
     SET(HAL_PREFIX stm32l0xx_)
 
@@ -118,11 +100,6 @@ ELSEIF(STM32_FAMILY STREQUAL "L4")
     SET(HAL_EX_COMPONENTS adc crc cryp dac dfsdm dma flash hash i2c ltdc 
                           opamp pcd pwr rcc rtc sai sd smartcard spi tim uart usart)
                           
-
-    # Components that have ll_ in names instead of hal_
-    SET(HAL_LL_COMPONENTS adc comp crc crs dac dma dma2d exti fmc gpio i2c lptim lpuart
-                          opamp pwr rcc rng rtc sdmmc spi swpmi tim usart usb utils)
-
     SET(HAL_PREFIX stm32l4xx_)
 
 ENDIF()
@@ -151,14 +128,9 @@ FOREACH(cmp ${STM32HAL_FIND_COMPONENTS})
     LIST(FIND HAL_COMPONENTS ${cmp} STM32HAL_FOUND_INDEX)
     IF(${STM32HAL_FOUND_INDEX} LESS 0)
         MESSAGE(FATAL_ERROR "Unknown STM32HAL component: ${cmp}. Available components: ${HAL_COMPONENTS}")
-    ENDIF()
-    LIST(FIND HAL_LL_COMPONENTS ${cmp} STM32HAL_FOUND_INDEX)
-    IF(${STM32HAL_FOUND_INDEX} LESS 0)
+	ELSE()
         LIST(APPEND HAL_HEADERS ${HAL_PREFIX}hal_${cmp}.h)
         LIST(APPEND HAL_SRCS ${HAL_PREFIX}hal_${cmp}.c)
-    ELSE()
-        LIST(APPEND HAL_HEADERS ${HAL_PREFIX}ll_${cmp}.h)
-        LIST(APPEND HAL_SRCS ${HAL_PREFIX}ll_${cmp}.c)
     ENDIF()
     LIST(FIND HAL_EX_COMPONENTS ${cmp} STM32HAL_FOUND_INDEX)
     IF(NOT (${STM32HAL_FOUND_INDEX} LESS 0))

--- a/cmake/FindSTM32LL.cmake
+++ b/cmake/FindSTM32LL.cmake
@@ -1,0 +1,117 @@
+SET(STM32LL_HEADER_ONLY_COMPONENTS	bus cortex iwdg system wwdg dmamux)
+
+IF(STM32_FAMILY STREQUAL "F0")
+    SET(LL_COMPONENTS	adc bus comp cortex crc crs dac dma exti gpio i2c
+						i2s iwdg pwr rcc rtc spi system tim usart utils wwdg)
+
+    SET(LL_REQUIRED_COMPONENTS bus cortex pwr rcc system utils)
+
+    SET(LL_PREFIX stm32f0xx_)
+
+ELSEIF(STM32_FAMILY STREQUAL "F1")
+    SET(LL_COMPONENTS	adc bus cortex crc dac dma exti gpio i2c
+						i2s iwdg pwr rcc rtc spi system tim usart utils wwdg)
+
+    SET(LL_REQUIRED_COMPONENTS bus cortex pwr rcc system utils)
+
+    SET(LL_PREFIX stm32f1xx_)
+
+ELSEIF(STM32_FAMILY STREQUAL "F2")
+    SET(LL_COMPONENTS	adc bus cortex crc dac dma exti gpio i2c i2s iwdg pwr 
+						rcc rng rtc spi system tim usart utils wwdg)
+
+    SET(LL_REQUIRED_COMPONENTS bus cortex pwr rcc system utils)
+
+    SET(LL_PREFIX stm32f2xx_)
+
+ELSEIF(STM32_FAMILY STREQUAL "F3")
+    SET(LL_COMPONENTS	adc bus comp cortex crc dac dma exti gpio hrtim i2c i2s
+						iwdg opamp pwr rcc rtc spi system tim usart utils wwdg)
+
+    SET(LL_REQUIRED_COMPONENTS bus cortex pwr rcc system utils)
+
+    SET(LL_PREFIX stm32f3xx_)
+
+ELSEIF(STM32_FAMILY STREQUAL "F4")
+    SET(LL_COMPONENTS	adc bus cortex crc dac dma2d dma exti gpio i2c i2s iwdg
+						lptim pwr rcc rng rtc spi system tim usart utils wwdg)
+
+    SET(LL_REQUIRED_COMPONENTS bus cortex pwr rcc system utils)
+
+    SET(LL_PREFIX stm32f4xx_)
+
+ELSEIF(STM32_FAMILY STREQUAL "F7")
+    SET(LL_COMPONENTS	adc bus cortex crc dac dma2d dma exti gpio i2c i2s iwdg
+						lptim pwr rcc rng rtc spi system tim usart utils wwdg)
+
+    SET(LL_REQUIRED_COMPONENTS bus cortex pwr rcc system utils)
+
+    SET(LL_PREFIX stm32f7xx_)
+
+ELSEIF(STM32_FAMILY STREQUAL "L0")
+    SET(LL_COMPONENTS	adc bus comp cortex crc crs dac dma exti gpio i2c i2s
+						iwdg lptim lpuart pwr rcc rng rtc spi system tim usart
+						utils wwdg)
+
+    SET(LL_REQUIRED_COMPONENTS bus cortex pwr rcc system utils)
+
+    SET(LL_PREFIX stm32l0xx_)
+
+ELSEIF(STM32_FAMILY STREQUAL "L4")
+    SET(LL_COMPONENTS	adc bus comp cortex crc crs dac dma2d dmamux dma exti 
+						gpio i2c iwdg lptim lpuart opamp pwr rcc rng rtc spi 
+						system tim usart utils wwdg)
+
+    SET(LL_REQUIRED_COMPONENTS bus cortex pwr rcc system utils)
+
+    SET(LL_PREFIX stm32l4xx_)
+
+ENDIF()
+
+ADD_DEFINITIONS(-DUSE_FULL_LL_DRIVER)
+
+FOREACH(cmp ${LL_REQUIRED_COMPONENTS})
+	LIST(FIND STM32LL_FIND_COMPONENTS ${cmp} STM32LL_FOUND_INDEX)
+	IF(${STM32LL_FOUND_INDEX} LESS 0)
+		LIST(APPEND STM32LL_FIND_COMPONENTS ${cmp})
+	ENDIF()
+ENDFOREACH()
+
+FOREACH(cmp ${STM32LL_FIND_COMPONENTS})
+	LIST(FIND LL_COMPONENTS ${cmp} STM32LL_FOUND_INDEX)
+	IF(${STM32LL_FOUND_INDEX} LESS 0)
+		MESSAGE(FATAL_ERROR "Unknown STM32LL component: ${cmp}. Available components: ${LL_COMPONENTS}")
+	ELSE()
+		LIST(FIND STM32LL_HEADER_ONLY_COMPONENTS ${cmp} HEADER_ONLY_FOUND_INDEX)
+		IF(${HEADER_ONLY_FOUND_INDEX} LESS 0)
+			LIST(APPEND LL_SRCS ${LL_PREFIX}ll_${cmp}.c)
+		ENDIF()
+		LIST(APPEND LL_HEADERS ${LL_PREFIX}ll_${cmp}.h)
+	ENDIF()
+ENDFOREACH()
+
+LIST(REMOVE_DUPLICATES LL_HEADERS)
+LIST(REMOVE_DUPLICATES LL_SRCS)
+
+STRING(TOLOWER ${STM32_FAMILY} STM32_FAMILY_LOWER)
+
+FIND_PATH(STM32LL_INCLUDE_DIR ${LL_HEADERS}
+	PATH_SUFFIXES include stm32${STM32_FAMILY_LOWER}
+	HINTS ${STM32Cube_DIR}/Drivers/STM32${STM32_FAMILY}xx_HAL_Driver/Inc
+	CMAKE_FIND_ROOT_PATH_BOTH
+)
+
+FOREACH(LL_SRC ${LL_SRCS})
+	STRING(MAKE_C_IDENTIFIER "${LL_SRC}" LL_SRC_CLEAN)
+	SET(LL_${LL_SRC_CLEAN}_FILE LL_SRC_FILE-NOTFOUND)
+	FIND_FILE(LL_${LL_SRC_CLEAN}_FILE ${LL_SRC}
+		PATH_SUFFIXES src stm32${STM32_FAMILY_LOWER}
+		HINTS ${STM32Cube_DIR}/Drivers/STM32${STM32_FAMILY}xx_HAL_Driver/Src
+		CMAKE_FIND_ROOT_PATH_BOTH
+	)
+	LIST(APPEND STM32LL_SOURCES ${LL_${LL_SRC_CLEAN}_FILE})
+ENDFOREACH()
+
+INCLUDE(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(STM32LL DEFAULT_MSG STM32LL_INCLUDE_DIR STM32LL_SOURCES)


### PR DESCRIPTION
I exported inclusion of LL components to separated FindSTM32LL.cmake and removed possibility to add LL components using STM32HAL package. I checked datasheets to search which LL components are available for each supported family. There are also some components which are implemented only using header file and it is also taken into account within FindSTM32LL.cmake. 