### PR TITLE
Fix gcc_stm32f3.cmake

### DIFF
--- a/cmake/gcc_stm32f3.cmake
+++ b/cmake/gcc_stm32f3.cmake
@@ -1,4 +1,4 @@
-SET(CMAKE_C_FLAGS "-mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -std=gnu11 -Os -ffunction-sections -fdata-sections -g -Wall" CACHE INTERNAL "c compiler flags")
+SET(CMAKE_C_FLAGS "-mthumb -fno-builtin -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -Wall -std=gnu99 -ffunction-sections -fdata-sections -fomit-frame-pointer -mabi=aapcs -fno-unroll-loops -ffast-math -ftree-vectorize" CACHE INTERNAL "c compiler flags")
 SET(CMAKE_CXX_FLAGS "-mthumb -fno-builtin -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard -Wall -std=c++11 -ffunction-sections -fdata-sections -fomit-frame-pointer -mabi=aapcs -fno-unroll-loops -ffast-math -ftree-vectorize" CACHE INTERNAL "cxx compiler flags")
 SET(CMAKE_ASM_FLAGS "-mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -g -Wa,--no-warn -x assembler-with-cpp" CACHE INTERNAL "asm compiler flags")
 


### PR DESCRIPTION
Add `-fno-builtin` and other flags that were only set for C++.

Specifically, adding `-fno-builtin` fixes some undefined reference to some `math.h` functiosn such as `ceil`, `floor` and `round`, when the link time optimizer is activated (with `-flto` flag).