### PR TITLE
fix STM32_CODES to upper case

### DIFF
--- a/cmake/gcc_stm32l4.cmake
+++ b/cmake/gcc_stm32l4.cmake
@@ -6,7 +6,7 @@ SET(CMAKE_EXE_LINKER_FLAGS "-Wl,--gc-sections -mthumb -mcpu=cortex-m4 -mfpu=fpv4
 SET(CMAKE_MODULE_LINKER_FLAGS "-mthumb -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mabi=aapcs" CACHE INTERNAL "module linker flags")
 SET(CMAKE_SHARED_LINKER_FLAGS "-mthumb -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mabi=aapcs" CACHE INTERNAL "shared linker flags")
 SET(STM32_CHIP_TYPES 431xx 432xx 433xx 442xx 443xx 451xx 452xx 462xx 471xx 475xx 476xx 485xx 486xx 496xx 4a6xx 4r5xx 4r7xx 4r9xx 4s5xx 4s7xx 4s9xx CACHE INTERNAL "stm32l4 chip types")
-SET(STM32_CODES "431.." "432.." "433.." "442.." "443.." "451.." "452.." "462.." "471.." "475.." "476.." "485.." "486.." "496.." "4a6.." "4r5.." "4r7.." "4r9.." "4s5.." "4s7.." "4s9..")
+SET(STM32_CODES "431.." "432.." "433.." "442.." "443.." "451.." "452.." "462.." "471.." "475.." "476.." "485.." "486.." "496.." "4A6.." "4R5.." "4R7.." "4R9.." "4S5.." "4S7.." "4S9..")
 
 MACRO(STM32_GET_CHIP_TYPE CHIP CHIP_TYPE)
     STRING(REGEX REPLACE "^[sS][tT][mM]32[lL](4[3456789ARS][1235679].[BCEGI]).*$" "\\1" STM32_CODE ${CHIP})


### PR DESCRIPTION
(As described in issue #85 as well. But here's a pull-request for this)

Hi,

I believe all code in this [line](https://github.com/ObKo/stm32-cmake/blob/e17159fb197e217191b4457e238599427f57dca7/cmake/gcc_stm32l4.cmake#L9)  must be upper case.

Thus not  
```cmake
SET(STM32_CODES ..... "4a6.." "4r5.." "4r7.." "4r9.." "4s5.." "4s7.." "4s9..")
```
but  
```cmake
SET(STM32_CODES ..... "4A6.." "4R5.." "4R7.." "4R9.." "4S5.." "4S7.." "4S9..")
```

Otherwise a line such as this will not succeed:

```bash 
cmake -DSTM32_CHIP=STM32L4R5VI `#-DSTM32_CHIP_TYPE=4r5xx` -DSTM32Cube_DIR=~/projects/arm/stm32/STM32Cube_FW_L4_V1.13.0    `#-DSTM32_FAMILY=L4` -DCMAKE_TOOLCHAIN_FILE=../cmake/gcc_stm32.cmake -DCMAKE_BUILD_TYPE=Debug ../stm32-blinky/
```

According to [this](https://www.st.com/resource/en/datasheet/stm32l4r5vi.pdf#page=2) valid names for the L4 family seem to be
STM32L4R5VI, STM32L4R5QI, STM32L4R5ZI, STM32L4R5AI, STM32L4R5AG, STM32L4R5QG, STM32L4R5VG, STM32L4R5ZG