### PR TITLE
Fix HAL_stm32f1xx_hal_spi_ex_c_FILE-NOTFOUND for F1 family

### DIFF
--- a/cmake/FindSTM32HAL.cmake
+++ b/cmake/FindSTM32HAL.cmake
@@ -18,7 +18,7 @@ ELSEIF(STM32_FAMILY STREQUAL "F1")
     SET(HAL_REQUIRED_COMPONENTS cortex pwr rcc)
 
     # Components that have _ex sources
-    SET(HAL_EX_COMPONENTS adc dac flash gpio pcd rcc rtc tim spi)
+    SET(HAL_EX_COMPONENTS adc dac flash gpio pcd rcc rtc tim)
 
     SET(HAL_PREFIX stm32f1xx_)
 


### PR DESCRIPTION
I was experiencing following issue:
```
CMake Error at CMakeLists.txt:66 (ADD_EXECUTABLE):
  Cannot find source file:

    HAL_stm32f1xx_hal_spi_ex_c_FILE-NOTFOUND

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .m .M .mm .h .hh .h++ .hm
  .hpp .hxx .in .txx
```
There is no `_ex.c` file for SPI in https://github.com/STMicroelectronics/STM32CubeF1/tree/master/Drivers/STM32F1xx_HAL_Driver/Src.  
