### PR TITLE
remove LL components for F7 builds

### DIFF
--- a/cmake/FindSTM32HAL.cmake
+++ b/cmake/FindSTM32HAL.cmake
@@ -65,7 +65,7 @@ ELSEIF(STM32_FAMILY STREQUAL "F7")
     SET(HAL_COMPONENTS adc can cec cortex crc cryp dac dcmi dma dma2d eth flash
                        gpio hash hcd i2c i2s irda iwdg lptim ltdc nand nor pcd
                        pwr qspi rcc rng rtc sai sd sdram smartcard spdifrx spi
-                       sram tim uart usart wwdg fmc sdmmc usb)
+                       sram tim uart usart wwdg)
 
     SET(HAL_REQUIRED_COMPONENTS cortex pwr rcc)
 


### PR DESCRIPTION
Proposed solution for https://github.com/ObKo/stm32-cmake/issues/148 to allow cmake builds for F7 boards.