### PR TITLE
docs: fix simple typo, similiar -> similar

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It uses cmake and GCC, along with newlib (libc), STM32Cube. Supports F0 F1 F2 F3
 ## Examples
 
 * `template` ([examples/template](examples/template)) - project template, empty source linked compiled with CMSIS.
-* `custom-linker-script` ([examples/custom-linker-script](examples/custom-linker-script)) - similiar to `template` but using custom linker script.
+* `custom-linker-script` ([examples/custom-linker-script](examples/custom-linker-script)) - similar to `template` but using custom linker script.
 * `fetch-cube` ([examples/fetch-cube](examples/fetch-cube)) - example of using FetchContent for fetching STM32Cube from ST's git.
 * `fetch-cmsis-hal` ([examples/fetch-cmsis-hal](examples/fetch-cmsis-hal)) - example of using FetchContent for fetching STM32 CMSIS and HAL from ST's git.
 * `blinky` ([examples/blinky](examples/blinky)) - blink led using STM32 HAL library and SysTick.
@@ -85,7 +85,7 @@ Also, there is special library `STM32::NoSys` which adds `--specs=nosys.specs` t
 
 ## HAL
 
-STM32 HAL can be used similiar to CMSIS.
+STM32 HAL can be used similar to CMSIS.
 ```
 find_package(HAL COMPONENTS STM32F4 REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)


### PR DESCRIPTION
There is a small typo in README.md.

Should read `similar` rather than `similiar`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md