### PR TITLE
Retrieve hal version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ You can do this by passing values through command line during cmake run or by se
 
 First thing that you need to do after toolchain configration in your `CMakeLists.txt` script is to find CMSIS package:
 ```
-find_package(CMSIS COMPONENTS STM32F4 REQUIRED)
+find_package(CMSIS [CMSIS_version] COMPONENTS STM32F4 REQUIRED)
 ```
 You can specify STM32 family or even specific device (`STM32F407VG`) in `COMPONENTS` or omit `COMPONENTS` totally - in that case stm32-cmake will find ALL sources for ALL families and ALL chips (you'll need ALL STM32Cube packages somewhere).
+
+[CMSIS_version] is an optional version requirement. See [find_package documentation](https://cmake.org/cmake/help/v3.13/command/find_package.html?highlight=find%20package#id4). This parameter does not make sense if multiples STM32 families are requested.
 
 Each STM32 device can be categorized into family and device type groups, for example STM32F407VG is device from `F4` family, with type `F407xx`.
 
@@ -87,10 +89,12 @@ Also, there is special library `STM32::NoSys` which adds `--specs=nosys.specs` t
 
 STM32 HAL can be used similar to CMSIS.
 ```
-find_package(HAL COMPONENTS STM32F4 REQUIRED)
+find_package(HAL [HAL_version] COMPONENTS STM32F4 REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 ```
 *`CMAKE_INCLUDE_CURRENT_DIR` here because HAL requires `stm32<family>xx_hal_conf.h` file being in include headers path.*
+
+[HAL_version] is an optional version requirement. See [find_package documentation](https://cmake.org/cmake/help/v3.13/command/find_package.html?highlight=find%20package#id4). This parameter does not make sense if multiples STM32 families are requested.
 
 HAL module will search all drivers supported by family and create following targets:
 

--- a/cmake/FindHAL.cmake
+++ b/cmake/FindHAL.cmake
@@ -243,7 +243,25 @@ foreach(COMP ${HAL_FIND_COMPONENTS_FAMILIES})
         set(STM32_CUBE_${FAMILY}_PATH /opt/STM32Cube${FAMILY} CACHE PATH "Path to STM32Cube${FAMILY}")
         message(STATUS "Neither STM32_CUBE_${FAMILY}_PATH nor STM32_HAL_${FAMILY}_PATH specified using default STM32_CUBE_${FAMILY}_PATH: ${STM32_CUBE_${FAMILY}_PATH}")
     endif()
-        
+
+    #Checking HAL patch or release version
+    unset(VERSION_INFO)
+    find_file(PACKAGE_FILE NAMES package.xml PATHS ${STM32_CUBE_${FAMILY}_PATH})
+    if(PACKAGE_FILE)
+        file(READ ${PACKAGE_FILE} PACKAGE_FILE_CONTENT)
+        string(REGEX MATCH "PackDescription Release=\"FW.${FAMILY}.([0-9.])+\"( Patch=\"FW.${FAMILY}.([0-9.]+)\")?" VERSION_INFO ${PACKAGE_FILE_CONTENT})
+        if(CMAKE_MATCH_3) # This is the "Patch" revision
+            set(HAL_${COMP}_VERSION ${CMAKE_MATCH_3})
+            set(HAL_VERSION ${CMAKE_MATCH_3})
+        else(CMAKE_MATCH_1) #This is the "Release" version 
+            set(HAL_${COMP}_VERSION ${CMAKE_MATCH_1})
+            set(HAL_VERSION ${CMAKE_MATCH_1})
+        endif()
+    endif()
+    if(NOT VERSION_INFO)
+        message(STATUS "Could not read the HAL version from package.xml for ${COMP}")
+    endif()
+
     find_path(HAL_${FAMILY}_PATH
         NAMES Inc/stm32${FAMILY_L}xx_hal.h
         PATHS "${STM32_HAL_${FAMILY}_PATH}" "${STM32_CUBE_${FAMILY}_PATH}/Drivers/STM32${FAMILY}xx_HAL_Driver"

--- a/cmake/FindHAL.cmake
+++ b/cmake/FindHAL.cmake
@@ -249,7 +249,7 @@ foreach(COMP ${HAL_FIND_COMPONENTS_FAMILIES})
     find_file(PACKAGE_FILE NAMES package.xml PATHS ${STM32_CUBE_${FAMILY}_PATH})
     if(PACKAGE_FILE)
         file(READ ${PACKAGE_FILE} PACKAGE_FILE_CONTENT)
-        string(REGEX MATCH "PackDescription Release=\"FW.${FAMILY}.([0-9.])+\"( Patch=\"FW.${FAMILY}.([0-9.]+)\")?" VERSION_INFO ${PACKAGE_FILE_CONTENT})
+        string(REGEX MATCH "PackDescription Release=\"FW.${FAMILY}.([0-9.]+)\"( Patch=\"FW.${FAMILY}.([0-9.]+)\")?" VERSION_INFO ${PACKAGE_FILE_CONTENT})
         if(CMAKE_MATCH_3) # This is the "Patch" revision
             set(HAL_${COMP}_VERSION ${CMAKE_MATCH_3})
             set(HAL_VERSION ${CMAKE_MATCH_3})
@@ -383,4 +383,3 @@ find_package_handle_standard_args(HAL
     FOUND_VAR HAL_FOUND
     HANDLE_COMPONENTS
 )
-


### PR DESCRIPTION
This closes #177.
As added in the Readme.md, the [find_package documentation](https://cmake.org/cmake/help/v3.13/command/find_package.html?highlight=find%20package#id4) explains the behavior of this parameter.