### PR TITLE
Adds support for the Newlib-Nano Standard Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ So, if you don't need linker script, you can link only `CMSIS::STM32::<TYPE>` li
 ***Note**: For H7 family, because of it multi-cores architecture, all H7 targets also have a suffix (::M7 or ::M4).
 For example, targets created for STM32H747BI will look like `CMSIS::STM32::H7::M7`, `CMSIS::STM32::H7::M4`, `CMSIS::STM32::H747BI::M7`, `CMSIS::STM32::H747BI::M4`, etc.*
 
-Also, there is special library `STM32::NoSys` which adds `--specs=nosys.specs` to compiler flags.
+The GCC C/C++ standard libraries are added by linking the library `STM32::NoSys`. This will add the `--specs=nosys.specs` to compiler and linker flags.
+If you want to use C++ on MCUs with little flash, you might instead want to link the newlib-nano to reduce the code size. You can do so by linking `STM32::Nano`, which will add the `--specs=nano.specs` flags to both compiler and linker.
+Keep in mind that when using `STM32::Nano`, by default you cannot use floats in printf/scanf calls, and you have to provide implementations for several OS interfacing functions (_sbrk, _close, _fstat, and others).
 
 ## HAL
 

--- a/cmake/stm32/common.cmake
+++ b/cmake/stm32/common.cmake
@@ -228,12 +228,20 @@ if(NOT (TARGET STM32::NoSys))
     add_library(STM32::NoSys INTERFACE IMPORTED)
     target_compile_options(STM32::NoSys INTERFACE $<$<C_COMPILER_ID:GNU>:--specs=nosys.specs>)
     target_link_options(STM32::NoSys INTERFACE $<$<C_COMPILER_ID:GNU>:--specs=nosys.specs>)
+    #This custom property is used to check that specs is not set yet on a target linking to this one
+    set_property(TARGET STM32::NoSys PROPERTY INTERFACE_CUSTOM_GCC_SPECS "NOSYS")
+    set_property(TARGET STM32::NoSys APPEND PROPERTY
+        COMPATIBLE_INTERFACE_STRING CUSTOM_GCC_SPECS)
 endif()
 
 if(NOT (TARGET STM32::Nano))
     add_library(STM32::Nano INTERFACE IMPORTED)
     target_compile_options(STM32::Nano INTERFACE $<$<C_COMPILER_ID:GNU>:--specs=nano.specs>)
     target_link_options(STM32::Nano INTERFACE $<$<C_COMPILER_ID:GNU>:--specs=nano.specs>)
+    #This custom property is used to check that specs is not set yet on a target linking to this one
+    set_property(TARGET STM32::Nano PROPERTY INTERFACE_CUSTOM_GCC_SPECS "NANO")
+    set_property(TARGET STM32::Nano APPEND PROPERTY
+        COMPATIBLE_INTERFACE_STRING CUSTOM_GCC_SPECS)
 endif()
 
 include(stm32/utilities)

--- a/cmake/stm32/common.cmake
+++ b/cmake/stm32/common.cmake
@@ -230,6 +230,12 @@ if(NOT (TARGET STM32::NoSys))
     target_link_options(STM32::NoSys INTERFACE $<$<C_COMPILER_ID:GNU>:--specs=nosys.specs>)
 endif()
 
+if(NOT (TARGET STM32::Nano))
+    add_library(STM32::Nano INTERFACE IMPORTED)
+    target_compile_options(STM32::Nano INTERFACE $<$<C_COMPILER_ID:GNU>:--specs=nano.specs>)
+    target_link_options(STM32::Nano INTERFACE $<$<C_COMPILER_ID:GNU>:--specs=nano.specs>)
+endif()
+
 include(stm32/utilities)
 include(stm32/f0)
 include(stm32/f1)


### PR DESCRIPTION
- For MCUs with very little flash, the Nano standard library is more suitable.
- This change supports building with the GCC nano stdlib, simply by
  linking STM32::Nano library in cmake.