### PR TITLE
print binary size

### DIFF
--- a/cmake/stm32/common.cmake
+++ b/cmake/stm32/common.cmake
@@ -10,11 +10,11 @@ foreach(FAMILY ${STM32_SUPPORTED_FAMILIES_LONG_NAME})
 endforeach()
 list(REMOVE_DUPLICATES STM32_SUPPORTED_FAMILIES_SHORT_NAME)
 
-if(NOT STM32_TOOLCHAIN_PATH AND NOT CMAKE_C_COMPILER)
-    set(STM32_TOOLCHAIN_PATH "/usr")
-    message(STATUS "No STM32_TOOLCHAIN_PATH specified, using default: " ${STM32_TOOLCHAIN_PATH})
-else()
-    if(NOT STM32_TOOLCHAIN_PATH)
+if(NOT STM32_TOOLCHAIN_PATH)
+    if(NOT CMAKE_C_COMPILER)
+        set(STM32_TOOLCHAIN_PATH "/usr")
+        message(STATUS "No STM32_TOOLCHAIN_PATH specified, using default: " ${STM32_TOOLCHAIN_PATH})
+    else()
         # keep only directory of compiler
         get_filename_component(STM32_TOOLCHAIN_PATH ${CMAKE_C_COMPILER} DIRECTORY)
         # remove the last /bin directory

--- a/cmake/stm32/common.cmake
+++ b/cmake/stm32/common.cmake
@@ -42,6 +42,12 @@ find_program(CMAKE_SIZE NAMES ${STM32_TARGET_TRIPLET}-size PATHS ${TOOLCHAIN_BIN
 find_program(CMAKE_DEBUGGER NAMES ${STM32_TARGET_TRIPLET}-gdb PATHS ${TOOLCHAIN_BIN_PATH} NO_DEFAULT_PATH)
 find_program(CMAKE_CPPFILT NAMES ${STM32_TARGET_TRIPLET}-c++filt PATHS ${TOOLCHAIN_BIN_PATH} NO_DEFAULT_PATH)
 
+FUNCTION(stm32_print_size_of_target TARGET)
+    # this target is always considered out of date so size will always be displayed on build
+    ADD_CUSTOM_TARGET(${TARGET}_size ALL COMMAND ${CMAKE_SIZE} ${TARGET}${CMAKE_EXECUTABLE_SUFFIX_C}
+                                                        DEPENDS ${TARGET}${CMAKE_EXECUTABLE_SUFFIX_C})
+ENDFUNCTION()
+
 function(stm32_get_chip_type FAMILY DEVICE TYPE)
     set(INDEX 0)
     foreach(C_TYPE ${STM32_${FAMILY}_TYPES})

--- a/cmake/stm32/common.cmake
+++ b/cmake/stm32/common.cmake
@@ -10,11 +10,17 @@ foreach(FAMILY ${STM32_SUPPORTED_FAMILIES_LONG_NAME})
 endforeach()
 list(REMOVE_DUPLICATES STM32_SUPPORTED_FAMILIES_SHORT_NAME)
 
-if(NOT STM32_TOOLCHAIN_PATH)
-     set(STM32_TOOLCHAIN_PATH "/usr")
-     message(STATUS "No STM32_TOOLCHAIN_PATH specified, using default: " ${STM32_TOOLCHAIN_PATH})
+if(NOT STM32_TOOLCHAIN_PATH AND NOT CMAKE_C_COMPILER)
+    set(STM32_TOOLCHAIN_PATH "/usr")
+    message(STATUS "No STM32_TOOLCHAIN_PATH specified, using default: " ${STM32_TOOLCHAIN_PATH})
 else()
-     file(TO_CMAKE_PATH "${STM32_TOOLCHAIN_PATH}" STM32_TOOLCHAIN_PATH)
+    if(NOT STM32_TOOLCHAIN_PATH)
+        # keep only directory of compiler
+        get_filename_component(STM32_TOOLCHAIN_PATH ${CMAKE_C_COMPILER} DIRECTORY)
+        # remove the last /bin directory
+        get_filename_component(STM32_TOOLCHAIN_PATH ${STM32_TOOLCHAIN_PATH} DIRECTORY)
+    endif()
+    file(TO_CMAKE_PATH "${STM32_TOOLCHAIN_PATH}" STM32_TOOLCHAIN_PATH)
 endif()
 
 if(NOT STM32_TARGET_TRIPLET)

--- a/examples/blinky-ll/CMakeLists.txt
+++ b/examples/blinky-ll/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(stm32-blinky-f4
     CMSIS::STM32::F407VG
     STM32::NoSys 
 )
+stm32_print_size_of_target(stm32-blinky-f4)
 
 # STM32VL-Discovery
 add_executable(stm32-blinky-f1 blinky.c)
@@ -24,6 +25,7 @@ target_link_libraries(stm32-blinky-f1
     CMSIS::STM32::F100RB
     STM32::NoSys
 )
+stm32_print_size_of_target(stm32-blinky-f1)
 
 # STM32L0538-Discovery
 add_executable(stm32-blinky-l0 blinky.c)
@@ -33,3 +35,4 @@ target_link_libraries(stm32-blinky-l0
     CMSIS::STM32::L053C8
     STM32::NoSys
 )
+stm32_print_size_of_target(stm32-blinky-l0)

--- a/examples/blinky/CMakeLists.txt
+++ b/examples/blinky/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(stm32-blinky-f4
     CMSIS::STM32::F407VG
     STM32::NoSys 
 )
+stm32_print_size_of_target(stm32-blinky-f4)
 
 # STM32VL-Discovery
 add_executable(stm32-blinky-f1 blinky.c stm32f1xx_hal_conf.h)
@@ -34,6 +35,7 @@ target_link_libraries(stm32-blinky-f1
     CMSIS::STM32::F100RB
     STM32::NoSys
 )
+stm32_print_size_of_target(stm32-blinky-f1)
 
 # STM32L0538-Discovery
 add_executable(stm32-blinky-l0 blinky.c stm32l0xx_hal_conf.h)
@@ -44,3 +46,4 @@ target_link_libraries(stm32-blinky-l0
     CMSIS::STM32::L053C8
     STM32::NoSys
 )
+stm32_print_size_of_target(stm32-blinky-l0)

--- a/examples/custom-linker-script/CMakeLists.txt
+++ b/examples/custom-linker-script/CMakeLists.txt
@@ -12,3 +12,4 @@ set(PROJECT_SOURCES
 add_executable(stm32-custom-linker-script ${PROJECT_SOURCES})
 target_link_libraries(stm32-custom-linker-script CMSIS::STM32::F407xx STM32::NoSys)
 stm32_add_linker_script(stm32-custom-linker-script PRIVATE F407VG.ld)
+stm32_print_size_of_target(stm32-custom-linker-script)

--- a/examples/fetch-cmsis-hal/CMakeLists.txt
+++ b/examples/fetch-cmsis-hal/CMakeLists.txt
@@ -15,6 +15,8 @@ set(PROJECT_SOURCES
 
 add_executable(stm32-fetch-f4 ${PROJECT_SOURCES})
 target_link_libraries(stm32-fetch-f4 CMSIS::STM32::F407VG STM32::NoSys)
+stm32_print_size_of_target(stm32-fetch-f4)
 
 add_executable(stm32-fetch-l0 ${PROJECT_SOURCES})
 target_link_libraries(stm32-fetch-l0 CMSIS::STM32::L053C8 STM32::NoSys)
+stm32_print_size_of_target(stm32-fetch-l0)

--- a/examples/fetch-cube/CMakeLists.txt
+++ b/examples/fetch-cube/CMakeLists.txt
@@ -13,6 +13,8 @@ set(PROJECT_SOURCES
 
 add_executable(stm32-fetch-f4 ${PROJECT_SOURCES})
 target_link_libraries(stm32-fetch-f4 CMSIS::STM32::F407VG STM32::NoSys)
+stm32_print_size_of_target(stm32-fetch-f4)
 
 add_executable(stm32-fetch-l0 ${PROJECT_SOURCES})
 target_link_libraries(stm32-fetch-l0 CMSIS::STM32::L053C8 STM32::NoSys)
+stm32_print_size_of_target(stm32-fetch-l0)

--- a/examples/freertos/CMakeLists.txt
+++ b/examples/freertos/CMakeLists.txt
@@ -24,3 +24,4 @@ target_link_libraries(stm32-freertos PRIVATE
     CMSIS::STM32::F407VG 
     STM32::NoSys
 )
+stm32_print_size_of_target(stm32-freertos)

--- a/examples/multi-core/CMakeLists.txt
+++ b/examples/multi-core/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(m7core PRIVATE
     CMSIS::STM32::H757VG::M7
     STM32::NoSys
     )
+stm32_print_size_of_target(m7core)
 
 target_link_libraries(m4core PRIVATE
     HAL::STM32::H7::M4::RCC
@@ -29,3 +30,4 @@ target_link_libraries(m4core PRIVATE
     CMSIS::STM32::H757VG::M4
     STM32::NoSys
     )
+stm32_print_size_of_target(m4core)

--- a/examples/template/CMakeLists.txt
+++ b/examples/template/CMakeLists.txt
@@ -15,3 +15,4 @@ set(PROJECT_SOURCES
 
 add_executable(stm32-template ${PROJECT_SOURCES})
 target_link_libraries(stm32-template CMSIS::STM32::F407VG STM32::NoSys)
+stm32_print_size_of_target(stm32-template)


### PR DESCRIPTION
closes #166 
The function is called `stm32_print_size_of_target`

I also added a small modification so that STM32_TOOLCHAIN_PATH could be set by CMAKE_C_COMPILER. As a VScode user, this is how the compiler is passed to cmake.