### PR TITLE
fixed find by board component

### DIFF
--- a/cmake/FindBSP.cmake
+++ b/cmake/FindBSP.cmake
@@ -322,13 +322,13 @@ foreach(COMP ${BSP_FIND_COMPONENTS})
         target_link_libraries(BSP::STM32::${FAMILY}${CORE_C}::${BCOMP_U} INTERFACE BSP::STM32::${FAMILY}${CORE_C} CMSIS::STM32::${FAMILY}${CORE_C})
         target_include_directories(BSP::STM32::${FAMILY}${CORE_C}::${BCOMP_U} INTERFACE "${BSP_${FAMILY}_PATH}/Components/${BCOMP}")
         
-        find_file(BSP_${BOARD_CANONICAL}_${COMP}_SOURCE
+        find_file(BSP_${BOARD_CANONICAL}_${BCOMP}_SOURCE
             NAMES ${BCOMP}.c
             PATHS "${BSP_${FAMILY}_PATH}/Components/${BCOMP}"
             NO_DEFAULT_PATH
         )
-        if (BSP_${BOARD_CANONICAL}_${COMP}_SOURCE)
-            target_sources(BSP::STM32::${FAMILY}${CORE_C}::${BCOMP_U} INTERFACE "${BSP_${BOARD_CANONICAL}_${COMP}_SOURCE}")
+        if (BSP_${BOARD_CANONICAL}_${BCOMP}_SOURCE)
+            target_sources(BSP::STM32::${FAMILY}${CORE_C}::${BCOMP_U} INTERFACE "${BSP_${BOARD_CANONICAL}_${BCOMP}_SOURCE}")
         endif()
     endforeach()
     


### PR DESCRIPTION
Using

```
find_package(BSP COMPONENTS 
            YOU BOARD
            REQUIRED)
```

caused the bsp interface libraries to all have the same source files since the find file variable was the same between each iteration of the board components. This fixes this issue.

See [this issue](https://github.com/ObKo/stm32-cmake/issues/198) for more information.