### PR TITLE
utilities.cmake update default build flags

### DIFF
--- a/cmake/stm32/utilities.cmake
+++ b/cmake/stm32/utilities.cmake
@@ -13,7 +13,7 @@ function(stm32_util_create_family_targets FAMILY)
 
     if(NOT (TARGET STM32::${FAMILY}${CORE_C}))
         set(STM32_COMPILE_OPTIONS
-            -mthumb -mabi=aapcs -Wall -ffunction-sections -fdata-sections
+            -mthumb -Wall -ffunction-sections -fdata-sections
         )
         if(STM32_ENABLE_FAST_MATH)
             list(APPEND STM32_COMPILE_OPTIONS -ffast-math)

--- a/cmake/stm32/utilities.cmake
+++ b/cmake/stm32/utilities.cmake
@@ -14,7 +14,7 @@ function(stm32_util_create_family_targets FAMILY)
     if(NOT (TARGET STM32::${FAMILY}${CORE_C}))
         add_library(STM32::${FAMILY}${CORE_C} INTERFACE IMPORTED)
         # Set compiler flags for target
-        # -Wall: all warning activated
+        # -Wall: all warnings activated
         # -ffunction-sections -fdata-sections: remove unused code
         target_compile_options(STM32::${FAMILY}${CORE_C} INTERFACE 
             --sysroot="${TOOLCHAIN_SYSROOT}"

--- a/cmake/stm32/utilities.cmake
+++ b/cmake/stm32/utilities.cmake
@@ -12,15 +12,11 @@ function(stm32_util_create_family_targets FAMILY)
     endif()
 
     if(NOT (TARGET STM32::${FAMILY}${CORE_C}))
-        # Remove unused code, generate thumb code and enable all warnings
-        set(STM32_COMPILE_OPTIONS
-            -mthumb -Wall -ffunction-sections -fdata-sections
-        )
-
         add_library(STM32::${FAMILY}${CORE_C} INTERFACE IMPORTED)
+        # Remove unused code, generate thumb code and enable all warnings
         target_compile_options(STM32::${FAMILY}${CORE_C} INTERFACE 
             --sysroot="${TOOLCHAIN_SYSROOT}"
-            ${STM32_COMPILE_OPTIONS}
+            -mthumb -Wall -ffunction-sections -fdata-sections
         )
         # Remove unused code, generate thumb code
         target_link_options(STM32::${FAMILY}${CORE_C} INTERFACE 

--- a/cmake/stm32/utilities.cmake
+++ b/cmake/stm32/utilities.cmake
@@ -13,12 +13,16 @@ function(stm32_util_create_family_targets FAMILY)
 
     if(NOT (TARGET STM32::${FAMILY}${CORE_C}))
         add_library(STM32::${FAMILY}${CORE_C} INTERFACE IMPORTED)
-        # Remove unused code, generate thumb code and enable all warnings
+        # Set compiler flags for target
+        # -Wall: all warning activated
+        # -ffunction-sections -fdata-sections: remove unused code
         target_compile_options(STM32::${FAMILY}${CORE_C} INTERFACE 
             --sysroot="${TOOLCHAIN_SYSROOT}"
             -mthumb -Wall -ffunction-sections -fdata-sections
         )
-        # Remove unused code, generate thumb code
+        # Set linker flags
+        # -mthumb: Generate thumb code
+        # -Wl,--gc-sections: Remove unused code
         target_link_options(STM32::${FAMILY}${CORE_C} INTERFACE 
             --sysroot="${TOOLCHAIN_SYSROOT}"
             -mthumb -Wl,--gc-sections

--- a/cmake/stm32/utilities.cmake
+++ b/cmake/stm32/utilities.cmake
@@ -11,10 +11,6 @@ function(stm32_util_create_family_targets FAMILY)
         message(FATAL_ERROR "Expected at most one core for family ${FAMILY}: ${CORES}")
     endif()
 
-    option(STM32_ENABLE_FAST_MATH "Add -ffast-math compiler flag" OFF)
-    option(STM32_NO_BUILTIN "Add -fno-builtin compiler flag" OFF)
-    option(STM32_NO_STRICT_ALIASING "Add -fno-strict-aliasing compiler flag" OFF)
-
     if(NOT (TARGET STM32::${FAMILY}${CORE_C}))
         set(STM32_COMPILE_OPTIONS
             -mthumb -mabi=aapcs -Wall -ffunction-sections -fdata-sections
@@ -164,4 +160,3 @@ function(stm32_fetch_hal)
         set(STM32_HAL_${FAMILY}_PATH ${${HAL_NAME_L}_SOURCE_DIR} PARENT_SCOPE)
     endforeach()
 endfunction()
-

--- a/cmake/stm32/utilities.cmake
+++ b/cmake/stm32/utilities.cmake
@@ -12,27 +12,20 @@ function(stm32_util_create_family_targets FAMILY)
     endif()
 
     if(NOT (TARGET STM32::${FAMILY}${CORE_C}))
+        # Remove unused code, generate thumb code and enable all warnings
         set(STM32_COMPILE_OPTIONS
             -mthumb -Wall -ffunction-sections -fdata-sections
         )
-        if(STM32_ENABLE_FAST_MATH)
-            list(APPEND STM32_COMPILE_OPTIONS -ffast-math)
-        endif()
-        if(STM32_NO_BUILTIN)
-            list(APPEND STM32_COMPILE_OPTIONS -fno-builtin)
-        endif()
-        if(STM32_NO_STRICT_ALIASING)
-            list(APPEND STM32_COMPILE_OPTIONS -fno-strict-aliasing)
-        endif()
 
         add_library(STM32::${FAMILY}${CORE_C} INTERFACE IMPORTED)
         target_compile_options(STM32::${FAMILY}${CORE_C} INTERFACE 
             --sysroot="${TOOLCHAIN_SYSROOT}"
             ${STM32_COMPILE_OPTIONS}
         )
+        # Remove unused code, generate thumb code
         target_link_options(STM32::${FAMILY}${CORE_C} INTERFACE 
             --sysroot="${TOOLCHAIN_SYSROOT}"
-            -mthumb -mabi=aapcs -Wl,--gc-sections
+            -mthumb -Wl,--gc-sections
         )
         target_compile_definitions(STM32::${FAMILY}${CORE_C} INTERFACE 
             STM32${FAMILY}


### PR DESCRIPTION
Closes #228 . This makes some optimization flags optional. There is also the option to remove them altogether. If they are not removed, I might add some documentation.

I also removed the enforcement of optimization flags for build configurations