### PR TITLE
CMSIS RTOS Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,17 +211,20 @@ stm32-cmake contains additional CMake modules for finding and configuring variou
 `FREERTOS_PATH` can be either the path to the whole
 [FreeRTOS/FreeRTOS](https://github.com/FreeRTOS/FreeRTOS) github repo, or the path to
 FreeRTOS-Kernel (usually located in the subfolder `FreeRTOS` on a downloaded release).
-You can supply `FREERTOS_PATH` as an environmental variable as well.
+`FREERTOS_PATH` can be supplied as an environmental variable as well.
 
-You can either use the FreeRTOS kernel provided in the Cube repositories, or a separate
+It is possible to either use the FreeRTOS kernel provided in the Cube repositories, or a separate
 FreeRTOS kernel. The Cube repository also provides the CMSIS RTOS and CMSIS RTOS V2 implementations.
-If you like to use the CMSIS implementations, it is recommended to also use the FreeRTOS sources
+If the CMSIS implementations is used, it is recommended to also use the FreeRTOS sources
 provided in the Cube repository because the CMSIS port might be incompatible to newer kernel
-versions.
+versions. The FreeRTOS port to use is specified as a `FreeRTOS` component. A list of available
+ports can be found below. If the FreeRTOS sources provided in the Cube repository are used, the
+device family also has to be specified as a component for the `FreeRTOS` package.
 
-You can specify to use CMSIS with a `CMSIS` target and by finding the CMSIS `RTOS` package.
-To select which FreeRTOS to use, you can find the package for a specific FreeRTOS port and then
-link against that port target within a specific namespace.
+CMSIS RTOS can be used by specifying a `CMSIS` target and by finding the CMSIS `RTOS` package.
+The following section will show a few example configurations for the H7 and F4 family.
+You can also find example code for the `H743ZI` and `F407VG` devices in the `examples`
+folder.
 
 Typical usage for a H7 device when using the M7 core, using an external kernel without CMSIS
 support. The FreeRTOS namespace is set to `FreeRTOS` and the `ARM_CM7` port is used:
@@ -247,7 +250,8 @@ target_link_libraries(${TARGET_NAME} PRIVATE
 ```
 
 Another typical usage using the FreeRTOS provided in the Cube repository and the CMSIS support.
-The FreeRTOS namespace is set to `FreeRTOS::STM32::<FAMILY>` and the `ARM_CM7` port is used:
+The FreeRTOS namespace is set to `FreeRTOS::STM32::<FAMILY>`, the `ARM_CM7` port is used and
+the device family is specified as a `FreeRTOS` component with `STM32H7`:
 
 ```cmake
 find_package(CMSIS COMPONENTS STM32H743ZI STM32H7_M7 RTOS REQUIRED)
@@ -269,7 +273,7 @@ in the Cube repository
 
 * `FreeRTOS::STM32::<Family>`
 
-For the multi-core architectures, you have to specify both family and core like specified in the
+For the multi-core architectures, both family and core need to be specified like shown in the
 example above.
 
 The following FreeRTOS ports are supported in general: `ARM_CM0`, `ARM_CM3`, `ARM_CM4F`, `ARM_CM7`,

--- a/README.md
+++ b/README.md
@@ -212,7 +212,10 @@ Typical usage:
 
 ```cmake
 find_package(FreeRTOS COMPONENTS ARM_CM4F REQUIRED)
-target_link_libraries(... FreeRTOS::ARM_CM4F)
+target_link_libraries(${TARGET_NAME} PRIVATE
+    ...
+    FreeRTOS::ARM_CM4F
+)
 ```
 
 The following FreeRTOS ports are supported: `ARM_CM0`, `ARM_CM3`, `ARM_CM4F`, `ARM_CM7`.
@@ -224,3 +227,26 @@ Other FreeRTOS libraries:
 * `FreeRTOS::StreamBuffer` - stream buffer (`stream_buffer.c`)
 * `FreeRTOS::Timers` - timers (`timers.c`)
 * `FreeRTOS::Heap::<N>` - heap implementation (`heap_<N>.c`), `<N>`: [1-5]
+
+The STM32Cube packages can contain the FreeRTOS source package and a CMSIS RTOS and RTOS_V2
+implementation. You can specify to use CMSIS with a `CMSIS` target and by finding the CMSIS
+`RTOS` package.
+
+Typical usage for a H7 device when using the M7 core with CMSIS `RTOS`:
+
+```cmake
+find_package(CMSIS COMPONENTS STM32H743ZI STM32H7_M7 RTOS REQUIRED)
+target_link_libraries(${TARGET_NAME} PRIVATE
+    ...
+    FreeRTOS::ARM_CM7
+    CMSIS::STM32::H7::M7::RTOS
+)
+```
+
+The following targets are available in general:
+
+* `CMSIS::STM32::<Family>::RTOS`
+* `CMSIS::STM32::<Family>::RTOS_V2`
+
+For the multi-core architectures, you have to specify both family and core like specified in the
+example.

--- a/cmake/FindCMSIS.cmake
+++ b/cmake/FindCMSIS.cmake
@@ -9,15 +9,18 @@ if(STM32H7 IN_LIST CMSIS_FIND_COMPONENTS)
 endif()
 list(REMOVE_DUPLICATES CMSIS_FIND_COMPONENTS)
 
+# This section fills the RTOS or family components list
 foreach(COMP ${CMSIS_FIND_COMPONENTS})
     string(TOLOWER ${COMP} COMP_L)
     string(TOUPPER ${COMP} COMP)
 
+    # Component is RTOS component
     if(${COMP} IN_LIST CMSIS_RTOS)
         list(APPEND CMSIS_FIND_COMPONENTS_RTOS ${COMP})
         continue()
     endif()
 
+    # Component is not RTOS component, so check whether it is a family component
     string(REGEX MATCH "^STM32([A-Z][0-9])([0-9A-Z][0-9][A-Z][0-9A-Z])?_?(M[47])?.*$" COMP ${COMP})
     if(CMAKE_MATCH_1)
         list(APPEND CMSIS_FIND_COMPONENTS_FAMILIES ${COMP})

--- a/cmake/FindFreeRTOS.cmake
+++ b/cmake/FindFreeRTOS.cmake
@@ -1,9 +1,7 @@
+set(FreeRTOS_PORTS ARM_CM0 ARM_CM3 ARM_CM4F ARM_CM7)
 if(NOT FreeRTOS_FIND_COMPONENTS)
-    set(FreeRTOS_FIND_COMPONENTS
-        ARM_CM0 ARM_CM3 ARM_CM4F ARM_CM7
-    )
+    set(FreeRTOS_FIND_COMPONENTS ${FreeRTOS_PORTS})
 endif()
-list(REMOVE_DUPLICATES FreeRTOS_FIND_COMPONENTS)
 
 set(FreeRTOS_HEAPS 1 2 3 4 5)
 
@@ -46,41 +44,30 @@ if(NOT (TARGET FreeRTOS))
     target_include_directories(FreeRTOS INTERFACE "${FreeRTOS_COMMON_INCLUDE}")
 endif()
 
-if(NOT (TARGET FreeRTOS::Coroutine))
-    add_library(FreeRTOS::Coroutine INTERFACE IMPORTED)
-    target_sources(FreeRTOS::Coroutine INTERFACE "${FreeRTOS_SOURCE_DIR}/croutine.c")
-    target_link_libraries(FreeRTOS::Coroutine INTERFACE FreeRTOS)
-endif()
-
-if(NOT (TARGET FreeRTOS::EventGroups))
-    add_library(FreeRTOS::EventGroups INTERFACE IMPORTED)
-    target_sources(FreeRTOS::EventGroups INTERFACE "${FreeRTOS_SOURCE_DIR}/event_groups.c")
-    target_link_libraries(FreeRTOS::EventGroups INTERFACE FreeRTOS)
-endif()
-
-if(NOT (TARGET FreeRTOS::StreamBuffer))
-    add_library(FreeRTOS::StreamBuffer INTERFACE IMPORTED)
-    target_sources(FreeRTOS::StreamBuffer INTERFACE "${FreeRTOS_SOURCE_DIR}/stream_buffer.c")
-    target_link_libraries(FreeRTOS::StreamBuffer INTERFACE FreeRTOS)
-endif()
-
-if(NOT (TARGET FreeRTOS::Timers))
-    add_library(FreeRTOS::Timers INTERFACE IMPORTED)
-    target_sources(FreeRTOS::Timers INTERFACE "${FreeRTOS_SOURCE_DIR}/timers.c")
-    target_link_libraries(FreeRTOS::Timers INTERFACE FreeRTOS)
-endif()
-
-foreach(HEAP ${FreeRTOS_HEAPS})
-    if(NOT (TARGET FreeRTOS::Heap::${HEAP}))
-        add_library(FreeRTOS::Heap::${HEAP} INTERFACE IMPORTED)
-        target_sources(FreeRTOS::Heap::${HEAP} INTERFACE "${FreeRTOS_SOURCE_DIR}/portable/MemMang/heap_${HEAP}.c")
-        target_link_libraries(FreeRTOS::Heap::${HEAP} INTERFACE FreeRTOS)
+foreach(COMP ${FreeRTOS_FIND_COMPONENTS})
+    string(TOUPPER ${COMP} COMP)
+    string(REGEX MATCH "^STM32([A-Z][0-9])([0-9A-Z][0-9][A-Z][0-9A-Z])?_?(M[47])?.*$" FAMILY_COMP ${COMP})
+    if(CMAKE_MATCH_1)
+        list(APPEND FreeRTOS_FIND_COMPONENTS_FAMILIES ${FAMILY_COMP})
+        continue()
     endif()
+
+    list(APPEND FreeRTOS_FIND_COMPONENTS_PORTS ${COMP})
 endforeach()
 
-foreach(PORT ${FreeRTOS_FIND_COMPONENTS})
-    find_path(FreeRTOS_${PORT}_PATH
-        NAMES portmacro.h
+if(NOT FreeRTOS_FIND_COMPONENTS_PORTS)
+    set(FreeRTOS_FIND_COMPONENTS_PORTS ${FreeRTOS_PORTS})
+endif()
+
+list(REMOVE_DUPLICATES FreeRTOS_FIND_COMPONENTS)
+list(REMOVE_DUPLICATES FreeRTOS_FIND_COMPONENTS_PORTS)
+list(REMOVE_DUPLICATES FreeRTOS_FIND_COMPONENTS_FAMILIES)
+
+set(FreeRTOS_HEAPS 1 2 3 4 5)
+
+macro(stm32_find_freertos FreeRTOS_NAMESPACE FREERTOS_PATH)
+    find_path(FreeRTOS_COMMON_INCLUDE
+        NAMES FreeRTOS.h
         PATHS "${FREERTOS_PATH}" "${FREERTOS_PATH}/FreeRTOS" 
         PATH_SUFFIXES
             "portable/GCC/${PORT}/r0p1"
@@ -101,22 +88,137 @@ foreach(PORT ${FreeRTOS_FIND_COMPONENTS})
         PATHS "${FreeRTOS_${PORT}_PATH}"
         NO_DEFAULT_PATH
     )
-    if(NOT (TARGET FreeRTOS::${PORT}))
-        add_library(FreeRTOS::${PORT} INTERFACE IMPORTED)
-        target_link_libraries(FreeRTOS::${PORT} INTERFACE FreeRTOS)
-        target_sources(FreeRTOS::${PORT} INTERFACE "${FreeRTOS_${PORT}_SOURCE}")
-        target_include_directories(FreeRTOS::${PORT} INTERFACE "${FreeRTOS_${PORT}_PATH}")
+    if(NOT (TARGET FreeRTOS))
+        add_library(FreeRTOS INTERFACE IMPORTED)
+        target_sources(FreeRTOS INTERFACE 
+            "${FreeRTOS_SOURCE_DIR}/tasks.c"
+            "${FreeRTOS_SOURCE_DIR}/list.c"
+            "${FreeRTOS_SOURCE_DIR}/queue.c"
+        )
+        target_include_directories(FreeRTOS INTERFACE "${FreeRTOS_COMMON_INCLUDE}")
     endif()
-    
-    if(FreeRTOS_${PORT}_PATH AND 
-       FreeRTOS_${PORT}_SOURCE AND 
-       FreeRTOS_COMMON_INCLUDE AND
-       FreeRTOS_SOURCE_DIR)
-       set(FreeRTOS_${PORT}_FOUND TRUE)
-    else()
-       set(FreeRTOS_${PORT}_FOUND FALSE)
+
+    if(NOT (TARGET ${FreeRTOS_NAMESPACE}::Coroutine))
+        add_library(${FreeRTOS_NAMESPACE}::Coroutine INTERFACE IMPORTED)
+        target_sources(${FreeRTOS_NAMESPACE}::Coroutine INTERFACE "${FreeRTOS_SOURCE_DIR}/croutine.c")
+        target_link_libraries(${FreeRTOS_NAMESPACE}::Coroutine INTERFACE FreeRTOS)
     endif()
-endforeach()
+
+    if(NOT (TARGET ${FreeRTOS_NAMESPACE}::EventGroups))
+        add_library(${FreeRTOS_NAMESPACE}::EventGroups INTERFACE IMPORTED)
+        target_sources(${FreeRTOS_NAMESPACE}::EventGroups INTERFACE "${FreeRTOS_SOURCE_DIR}/event_groups.c")
+        target_link_libraries(${FreeRTOS_NAMESPACE}::EventGroups INTERFACE FreeRTOS)
+    endif()
+
+    if(NOT (TARGET ${FreeRTOS_NAMESPACE}::StreamBuffer))
+        add_library(${FreeRTOS_NAMESPACE}::StreamBuffer INTERFACE IMPORTED)
+        target_sources(${FreeRTOS_NAMESPACE}::StreamBuffer INTERFACE "${FreeRTOS_SOURCE_DIR}/stream_buffer.c")
+        target_link_libraries(${FreeRTOS_NAMESPACE}::StreamBuffer INTERFACE FreeRTOS)
+    endif()
+
+    if(NOT (TARGET ${FreeRTOS_NAMESPACE}::Timers))
+        add_library(${FreeRTOS_NAMESPACE}::Timers INTERFACE IMPORTED)
+        target_sources(${FreeRTOS_NAMESPACE}::Timers INTERFACE "${FreeRTOS_SOURCE_DIR}/timers.c")
+        target_link_libraries(${FreeRTOS_NAMESPACE}::Timers INTERFACE FreeRTOS)
+    endif()
+
+    foreach(HEAP ${FreeRTOS_HEAPS})
+        if(NOT (TARGET ${FreeRTOS_NAMESPACE}::Heap::${HEAP}))
+            add_library(${FreeRTOS_NAMESPACE}::Heap::${HEAP} INTERFACE IMPORTED)
+            target_sources(${FreeRTOS_NAMESPACE}::Heap::${HEAP} INTERFACE "${FreeRTOS_SOURCE_DIR}/portable/MemMang/heap_${HEAP}.c")
+            target_link_libraries(${FreeRTOS_NAMESPACE}::Heap::${HEAP} INTERFACE FreeRTOS)
+        endif()
+    endforeach()
+
+    foreach(PORT ${FreeRTOS_FIND_COMPONENTS_PORTS})
+        find_path(FreeRTOS_${PORT}_PATH
+            NAMES portmacro.h
+            PATHS "${FREERTOS_PATH}" "${FREERTOS_PATH}/FreeRTOS" 
+            PATH_SUFFIXES "Source/portable/GCC/${PORT}"  "Source/portable/GCC/${PORT}/r0p1"
+            NO_DEFAULT_PATH
+        )
+        list(APPEND FreeRTOS_INCLUDE_DIRS "${FreeRTOS_${PORT}_PATH}")
+        
+        find_file(FreeRTOS_${PORT}_SOURCE
+            NAMES port.c
+            PATHS "${FreeRTOS_${PORT}_PATH}"
+            NO_DEFAULT_PATH
+        )
+        if(NOT (TARGET ${FreeRTOS_NAMESPACE}::${PORT}))
+            add_library(${FreeRTOS_NAMESPACE}::${PORT} INTERFACE IMPORTED)
+            target_link_libraries(${FreeRTOS_NAMESPACE}::${PORT} INTERFACE FreeRTOS)
+            target_sources(${FreeRTOS_NAMESPACE}::${PORT} INTERFACE "${FreeRTOS_${PORT}_SOURCE}")
+            target_include_directories(${FreeRTOS_NAMESPACE}::${PORT} INTERFACE "${FreeRTOS_${PORT}_PATH}")
+        endif()
+        
+        if(FreeRTOS_${PORT}_PATH AND 
+           FreeRTOS_${PORT}_SOURCE AND 
+           FreeRTOS_COMMON_INCLUDE AND
+           FreeRTOS_SOURCE_DIR)
+           set(FreeRTOS_${PORT}_FOUND TRUE)
+        else()
+           set(FreeRTOS_${PORT}_FOUND FALSE)
+        endif()
+    endforeach()
+endmacro()
+
+if(NOT FreeRTOS_FIND_COMPONENTS_FAMILIES)
+    if(NOT FREERTOS_PATH)
+        set(FREERTOS_PATH /opt/FreeRTOS CACHE PATH "Path to FreeRTOS")
+        message(STATUS "No FREERTOS_PATH specified using default: ${FREERTOS_PATH}")
+    endif()
+    stm32_find_freertos(FreeRTOS ${FREERTOS_PATH})
+else()
+    message(STATUS "Search for FreeRTOS families: ${FreeRTOS_FIND_COMPONENTS_FAMILIES}")
+    message(STATUS "Search for FreeRTOS ports: ${FreeRTOS_FIND_COMPONENTS_PORTS}")
+
+    foreach(COMP ${FreeRTOS_FIND_COMPONENTS_FAMILIES})
+        string(TOLOWER ${COMP} COMP_L)
+        string(TOUPPER ${COMP} COMP)
+        
+        string(REGEX MATCH "^STM32([A-Z][0-9])([0-9A-Z][0-9][A-Z][0-9A-Z])?_?(M[47])?.*$" COMP ${COMP})
+        
+        if((NOT CMAKE_MATCH_1) AND (NOT CMAKE_MATCH_2))
+            message(FATAL_ERROR "Unknown FreeRTOS component: ${COMP}")
+        endif()
+        
+        if(CMAKE_MATCH_2)
+            set(FAMILY ${CMAKE_MATCH_1})
+            set(DEVICES "${CMAKE_MATCH_1}${CMAKE_MATCH_2}")
+        else()
+            set(FAMILY ${CMAKE_MATCH_1})
+            stm32_get_devices_by_family(DEVICES FAMILY ${FAMILY} CORE ${CORE})
+        endif()
+        
+        if(CMAKE_MATCH_3)
+            set(CORE ${CMAKE_MATCH_3})
+            set(CORE_C "::${CORE}")
+            set(CORE_U "_${CORE}")
+        else()
+            unset(CORE)
+            unset(CORE_C)
+            unset(CORE_U)
+        endif()
+        
+        string(TOLOWER ${FAMILY} FAMILY_L)
+        if(NOT STM32_CUBE_${FAMILY}_PATH)
+            set(STM32_CUBE_${FAMILY}_PATH /opt/STM32Cube${FAMILY} CACHE PATH "Path to STM32Cube${FAMILY}")
+            message(STATUS "Did not specify STM32_CMSIS_${FAMILY}_PATH, using default STM32_CUBE_${FAMILY}_PATH: ${STM32_CUBE_${FAMILY}_PATH}")
+        endif()
+        
+        stm32_find_freertos(FreeRTOS::STM32::${FAMILY}${CORE_C} ${STM32_CUBE_${FAMILY}_PATH}/Middlewares/Third_Party/FreeRTOS)
+        foreach(PORT_COMP ${FreeRTOS_FIND_COMPONENTS_PORTS})
+            if(FreeRTOS_${PORT_COMP}_PATH AND 
+               FreeRTOS_${PORT_COMP}_SOURCE AND 
+               FreeRTOS_COMMON_INCLUDE AND
+               FreeRTOS_SOURCE_DIR)
+               set(FreeRTOS_${COMP}_FOUND TRUE)
+            else()
+               set(FreeRTOS_${COMP}_FOUND FALSE)
+            endif()
+        endforeach()
+    endforeach()
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(FreeRTOS

--- a/cmake/FindFreeRTOS.cmake
+++ b/cmake/FindFreeRTOS.cmake
@@ -17,7 +17,7 @@ if(NOT FREERTOS_PATH)
     else()
         message(STATUS
             "No FreeRTOS folder found at default location ${DEFAULT_FREERTOS_PATH}. "
-            "Leaving empty"
+            "Leaving empty.."
         )
     endif()
 endif()
@@ -156,10 +156,6 @@ endmacro()
 message(STATUS "Search for FreeRTOS ports: ${FreeRTOS_FIND_COMPONENTS_PORTS}")
 
 if(NOT FreeRTOS_FIND_COMPONENTS_FAMILIES)
-    if(NOT FREERTOS_PATH)
-        set(FREERTOS_PATH /opt/FreeRTOS CACHE PATH "Path to FreeRTOS")
-        message(STATUS "No FREERTOS_PATH specified, using default: ${FREERTOS_PATH}")
-    endif()
     stm32_find_freertos(FreeRTOS ${FREERTOS_PATH})
 else()
     message(STATUS "Search for FreeRTOS families: ${FreeRTOS_FIND_COMPONENTS_FAMILIES}")

--- a/cmake/stm32/devices.cmake
+++ b/cmake/stm32/devices.cmake
@@ -1145,7 +1145,7 @@ function(stm32_get_devices_by_family STM_DEVICES)
         # No family argument, so get list of all devices
         set(RESULTING_DEV_LIST ${STM32_ALL_DEVICES})
     endif()
-    
+
     set(${STM_DEVICES} ${RESULTING_DEV_LIST} PARENT_SCOPE)
 endfunction()
 

--- a/examples/freertos/CMakeLists.txt
+++ b/examples/freertos/CMakeLists.txt
@@ -1,27 +1,169 @@
 cmake_minimum_required(VERSION 3.16)
-set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/stm32_gcc.cmake)
+set(PROJ_NAME stm32-freertos)
+set(STM32_CMAKE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 
-project(stm32-freertos C ASM)
+# Please note: When using CMSIS, it is recommended to use the FreeRTOS version supplied in the 
+# Cube repository because more recent kernels might be incompatible to the CMSIS
+# implementation provided by STM
+option(USE_CMSIS_RTOS "Use CMSIS RTOS provided by Cube repository" OFF)
+option(USE_CMSIS_RTOS_V2 "Use CMSIS RTOS_V2 provided by Cube repository" OFF)
+option(USE_CUBE_FREERTOS "Use the FreeRTOS kernel provided by the Cube repository" ON)
+
+if(USE_CUBE_FREERTOS)
+    message(STATUS "Using FreeRTOS provided by Cube repository")
+else()
+    message(STATUS "Using FreeRTOS from kernel repository")
+endif()
+
+if(USE_CMSIS_RTOS AND USE_CMSIS_RTOS_V2)
+    message(FATAL_ERROR "Can not use USE_CMSIS_RTOS_V2 together with USE_CMSIS_RTOS!")
+endif()
+
+if(USE_CMSIS_RTOS)
+    message(STATUS "Compiling CMSIS RTOS support")
+elseif(USE_CMSIS_RTOS_V2)
+    message(STATUS "Compiling CMSIS RTOS V2 support")
+endif()
+
+# This must come before the project call!
+set(CMAKE_TOOLCHAIN_FILE ${STM32_CMAKE_PATH}/cmake/stm32_gcc.cmake)
+project(${PROJ_NAME} CXX C ASM)
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 
-find_package(CMSIS COMPONENTS STM32F407VG REQUIRED)
-find_package(HAL COMPONENTS STM32F407VG REQUIRED)
-find_package(FreeRTOS COMPONENTS ARM_CM4F REQUIRED)
+# Can be used to print out all devices for the H7 family
+# include(${STM32_CMAKE_PATH}/cmake/stm32/devices.cmake)
+# stm32_print_devices_by_family(FAMILY H7)
+# stm32_print_devices_by_family(FAMILY F4)
+
+set(SUPPORTED_BOARDS F407VG H743ZI)
+option(FREERTOS_F407VG_EXAMPLE "Compile FreeRTOS example for the F407VG board" OFF)
+option(FREERTOS_H743ZI_EXAMPLE "Compile FreeRTOS example for the H743ZI board" OFF)
+
+if(NOT FREERTOS_F407VG_EXAMPLE AND NOT FREERTOS_H743ZI_EXAMPLE)
+    message(FATAL_ERROR
+        "Please select at least one target to compile by passing FREERTOS_<BOARD>_EXAMPLE=ON\n"
+        "Supported boards: ${SUPPORTED_BOARDS}"
+    )
+endif()
+
+set(HAL_COMP_LIST RCC GPIO CORTEX)
+set(CMSIS_COMP_LIST "")
+set(FREERTOS_COMP_LIST "")
+set(FREERTOS_NAMESPACE FreeRTOS)
+
+if(USE_CMSIS_RTOS)
+    list(APPEND CMSIS_COMP_LIST RTOS)
+endif()
+if(USE_CMSIS_RTOS_V2)
+    list(APPEND CMSIS_COMP_LIST RTOS_V2)
+endif()
+
+if(FREERTOS_H743ZI_EXAMPLE)
+    list(APPEND CMSIS_COMP_LIST STM32H743ZI STM32H7_M7)
+    list(APPEND HAL_COMP_LIST STM32H7M7 STM32H743ZI)
+    list(APPEND FREERTOS_COMP_LIST ARM_CM7)
+    list(APPEND FREERTOS_COMP_LIST STM32H7)
+    if(USE_CUBE_FREERTOS)
+        set(FREERTOS_H7_NAMESPACE ${FREERTOS_NAMESPACE}::STM32::H7::M7)
+    else()
+        set(FREERTOS_H7_NAMESPACE ${FREERTOS_NAMESPACE})
+    endif()
+endif()
+
+if(FREERTOS_F407VG_EXAMPLE)
+    list(APPEND CMSIS_COMP_LIST STM32F407VG)
+    list(APPEND HAL_COMP_LIST STM32F407VG)
+    list(APPEND FREERTOS_COMP_LIST ARM_CM4F)
+    if(USE_CMSIS_RTOS OR USE_CMSIS_RTOS_V2)
+        list(APPEND FREERTOS_COMP_LIST STM32F4)
+        set(FREERTOS_F4_NAMESPACE ${FREERTOS_NAMESPACE}::STM32::F4)
+     else()
+        set(FREERTOS_F4_NAMESPACE ${FREERTOS_NAMESPACE})
+    endif()
+endif()
+
+find_package(CMSIS COMPONENTS ${CMSIS_COMP_LIST} REQUIRED)
+find_package(HAL COMPONENTS ${HAL_COMP_LIST} REQUIRED)
+find_package(FreeRTOS COMPONENTS ${FREERTOS_COMP_LIST} REQUIRED)
 
 set(PROJECT_SOURCES
-    main.c
-    FreeRTOSConfig.h
+    main.cpp
 )
 
-add_executable(stm32-freertos ${PROJECT_SOURCES} stm32f4xx_hal_conf.h)
-target_link_libraries(stm32-freertos PRIVATE
-    FreeRTOS::Timers
-    FreeRTOS::Heap::1
-    FreeRTOS::ARM_CM4F 
-    HAL::STM32::F4::RCC
-    HAL::STM32::F4::GPIO
-    HAL::STM32::F4::CORTEX
-    CMSIS::STM32::F407VG 
-    STM32::NoSys
+# This is required because FreeRTOSConfig.h, stm32hxx_hal_conf.h and main.h
+# need to be included
+set(INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}
 )
-stm32_print_size_of_target(stm32-freertos)
+
+if(FREERTOS_H743ZI_EXAMPLE)
+    set(TARGET_NAME ${PROJ_NAME}-h743zi)
+    add_executable(${TARGET_NAME})
+
+    target_sources(${TARGET_NAME} PRIVATE ${PROJECT_SOURCES})
+    target_include_directories(${TARGET_NAME} PRIVATE ${INCLUDE_DIRS})
+    target_link_libraries(${TARGET_NAME} PRIVATE
+        ${FREERTOS_H7_NAMESPACE}::Timers
+        ${FREERTOS_H7_NAMESPACE}::Heap::4
+        ${FREERTOS_H7_NAMESPACE}::ARM_CM7
+        HAL::STM32::H7::M7::RCC
+        HAL::STM32::H7::M7::GPIO
+        HAL::STM32::H7::M7::CORTEX
+        CMSIS::STM32::H743ZI::M7
+        STM32::NoSys
+    )
+    if(USE_CMSIS_RTOS)
+        target_link_libraries(${TARGET_NAME} PRIVATE
+            CMSIS::STM32::H7::M7::RTOS
+        )
+    endif()
+    if(USE_CMSIS_RTOS_V2)
+        target_link_libraries(${TARGET_NAME} PRIVATE
+            CMSIS::STM32::H7::M7::RTOS_V2
+        )
+        target_compile_definitions(${TARGET_NAME} PRIVATE
+            USE_CMSIS_RTOS_V2
+            CMSIS_RTOS_V2_DEVICE_HEADER="stm32h7xx_hal.h"
+        )
+    endif()
+
+    stm32_print_size_of_target(${TARGET_NAME})
+    stm32_generate_binary_file(${TARGET_NAME})
+    stm32_generate_hex_file(${TARGET_NAME})
+endif()
+
+if(FREERTOS_F407VG_EXAMPLE)
+    set(TARGET_NAME ${PROJ_NAME}-f407vg)
+    add_executable(${TARGET_NAME})
+
+    target_sources(${TARGET_NAME} PRIVATE ${PROJECT_SOURCES})
+    target_include_directories(${TARGET_NAME} PRIVATE ${INCLUDE_DIRS})
+    target_link_libraries(${TARGET_NAME} PRIVATE
+        ${FREERTOS_F4_NAMESPACE}::Timers
+        ${FREERTOS_F4_NAMESPACE}::Heap::1
+        ${FREERTOS_F4_NAMESPACE}::ARM_CM4F
+        HAL::STM32::F4::RCC
+        HAL::STM32::F4::GPIO
+        HAL::STM32::F4::CORTEX
+        CMSIS::STM32::F407VG 
+        STM32::NoSys
+    )
+    if(USE_CMSIS_RTOS)
+        target_link_libraries(${TARGET_NAME} PRIVATE
+            CMSIS::STM32::F4::RTOS
+        )
+    endif()
+    if(USE_CMSIS_RTOS_V2)
+        target_link_libraries(${TARGET_NAME} PRIVATE
+            CMSIS::STM32::F4::RTOS_V2
+        )
+        target_compile_definitions(${TARGET_NAME} PRIVATE
+            USE_CMSIS_RTOS_V2
+            CMSIS_RTOS_V2_DEVICE_HEADER="stm32f4xx_hal.h"
+        )
+    endif()
+
+    stm32_print_size_of_target(${TARGET_NAME})
+    stm32_generate_binary_file(${TARGET_NAME})
+    stm32_generate_hex_file(${TARGET_NAME})
+endif()

--- a/examples/freertos/CMakeLists.txt
+++ b/examples/freertos/CMakeLists.txt
@@ -30,8 +30,7 @@ set(CMAKE_TOOLCHAIN_FILE ${STM32_CMAKE_PATH}/cmake/stm32_gcc.cmake)
 project(${PROJ_NAME} CXX C ASM)
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 
-# Can be used to print out all devices for the H7 family
-# include(${STM32_CMAKE_PATH}/cmake/stm32/devices.cmake)
+# Can be used to print out all devices for the H7 or/and the F4 family
 # stm32_print_devices_by_family(FAMILY H7)
 # stm32_print_devices_by_family(FAMILY F4)
 
@@ -59,11 +58,12 @@ if(USE_CMSIS_RTOS_V2)
 endif()
 
 if(FREERTOS_H743ZI_EXAMPLE)
-    list(APPEND CMSIS_COMP_LIST STM32H743ZI STM32H7_M7)
-    list(APPEND HAL_COMP_LIST STM32H7M7 STM32H743ZI)
+    list(APPEND CMSIS_COMP_LIST STM32H743ZI_M7)
+    list(APPEND HAL_COMP_LIST STM32H7M7)
     list(APPEND FREERTOS_COMP_LIST ARM_CM7)
-    list(APPEND FREERTOS_COMP_LIST STM32H7)
     if(USE_CUBE_FREERTOS)
+        # The device family needs to be supplied as a component to use the Cube FreeRTOS sources
+        list(APPEND FREERTOS_COMP_LIST STM32H7)
         set(FREERTOS_H7_NAMESPACE ${FREERTOS_NAMESPACE}::STM32::H7::M7)
     else()
         set(FREERTOS_H7_NAMESPACE ${FREERTOS_NAMESPACE})
@@ -74,7 +74,8 @@ if(FREERTOS_F407VG_EXAMPLE)
     list(APPEND CMSIS_COMP_LIST STM32F407VG)
     list(APPEND HAL_COMP_LIST STM32F407VG)
     list(APPEND FREERTOS_COMP_LIST ARM_CM4F)
-    if(USE_CMSIS_RTOS OR USE_CMSIS_RTOS_V2)
+    if(USE_CUBE_FREERTOS)
+        # The device family needs to be supplied as a component to use the Cube FreeRTOS sources
         list(APPEND FREERTOS_COMP_LIST STM32F4)
         set(FREERTOS_F4_NAMESPACE ${FREERTOS_NAMESPACE}::STM32::F4)
      else()

--- a/examples/freertos/FreeRTOSConfig.h
+++ b/examples/freertos/FreeRTOSConfig.h
@@ -49,7 +49,9 @@ extern uint32_t SystemCoreClock;
 #define configUSE_TICK_HOOK				1
 #define configCPU_CLOCK_HZ				( SystemCoreClock )
 #define configTICK_RATE_HZ				( ( TickType_t ) 1000 )
+#if !defined USE_CMSIS_RTOS_V2
 #define configMAX_PRIORITIES			( 5 )
+#endif
 #define configMINIMAL_STACK_SIZE		( ( unsigned short ) 130 )
 #define configTOTAL_HEAP_SIZE			( ( size_t ) ( 8 * 1024 ) )
 #define configMAX_TASK_NAME_LEN			( 10 )
@@ -85,6 +87,26 @@ to exclude the API function. */
 #define INCLUDE_vTaskDelayUntil			1
 #define INCLUDE_vTaskDelay				1
 
+#if defined USE_CMSIS_RTOS_V2
+
+#ifndef CMSIS_RTOS_V2_DEVICE_HEADER
+#error "CMSIS device header needs to be passed by the build system"
+#endif
+#define CMSIS_device_header CMSIS_RTOS_V2_DEVICE_HEADER
+
+/* Needed for CMSIS RTOS_V2 */
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION 0
+#define configMAX_PRIORITIES 56
+
+#define INCLUDE_xSemaphoreGetMutexHolder 1
+#define INCLUDE_xTaskGetCurrentTaskHandle 1
+#define INCLUDE_xTaskGetSchedulerState 1
+#define INCLUDE_uxTaskGetStackHighWaterMark 1
+#define INCLUDE_eTaskGetState 1
+#define INCLUDE_xTimerPendFunctionCall 1
+
+#endif
+
 /* Cortex-M specific definitions. */
 #ifdef __NVIC_PRIO_BITS
 	/* __BVIC_PRIO_BITS will be specified when CMSIS is being used. */
@@ -118,7 +140,11 @@ header file. */
 standard names. */
 #define vPortSVCHandler SVC_Handler
 #define xPortPendSVHandler PendSV_Handler
+
+/* When using CMSIS RTOS V2, this define causes  a multiple definition error */
+#if !defined USE_CMSIS_RTOS_V2
 #define xPortSysTickHandler SysTick_Handler
+#endif
 
 #endif /* FREERTOS_CONFIG_H */
 

--- a/examples/freertos/main.cpp
+++ b/examples/freertos/main.cpp
@@ -1,0 +1,79 @@
+#include "main.h"
+#include <FreeRTOS.h>
+#include <task.h>
+#include <timers.h>
+
+#if defined STM32H7
+    #include <stm32h7xx_hal.h>
+
+    // STM32H743ZI blue LED
+    #define LED_PORT                GPIOB
+    #define LED_PIN                 GPIO_PIN_7
+    #define LED_PORT_CLK_ENABLE     __HAL_RCC_GPIOB_CLK_ENABLE
+#elif defined STM32F4
+    #include <stm32f4xx_hal.h>
+
+    // STM32F4-Discovery green led - PD12
+    #define LED_PORT                GPIOD
+    #define LED_PIN                 GPIO_PIN_12
+    #define LED_PORT_CLK_ENABLE     __HAL_RCC_GPIOD_CLK_ENABLE
+#endif
+
+static void blinky::blinkTask(void *arg)
+{
+    for(;;)
+    {
+        vTaskDelay(500);
+        HAL_GPIO_TogglePin(LED_PORT, LED_PIN);
+    }
+}
+
+void blinky::init()
+{
+    GPIO_InitTypeDef GPIO_Config;
+
+    GPIO_Config.Mode = GPIO_MODE_OUTPUT_PP;
+    GPIO_Config.Pull = GPIO_NOPULL;
+    GPIO_Config.Speed = GPIO_SPEED_FREQ_HIGH;
+
+    GPIO_Config.Pin = LED_PIN;
+
+    LED_PORT_CLK_ENABLE();
+    HAL_GPIO_Init(LED_PORT, &GPIO_Config);
+}
+
+int main(void)
+{
+    SystemInit();
+    blinky::init();
+    
+    xTaskCreate(blinky::blinkTask, "blinky", configMINIMAL_STACK_SIZE * 4, NULL, tskIDLE_PRIORITY + 1, NULL);
+    
+    vTaskStartScheduler();
+    for (;;);
+    
+    return 0;
+}
+
+extern "C" void vApplicationTickHook(void)
+{
+}
+
+extern "C" void vApplicationIdleHook(void)
+{
+}
+
+extern "C" void vApplicationMallocFailedHook(void)
+{
+    taskDISABLE_INTERRUPTS();
+    for(;;);
+}
+
+extern "C" void vApplicationStackOverflowHook(TaskHandle_t pxTask, char *pcTaskName)
+{
+    (void) pcTaskName;
+    (void) pxTask;
+
+    taskDISABLE_INTERRUPTS();
+    for(;;);
+}

--- a/examples/freertos/main.h
+++ b/examples/freertos/main.h
@@ -1,0 +1,11 @@
+#ifndef STM32_CMAKE_EXAMPLES_FREERTOS_MAIN_H_
+#define STM32_CMAKE_EXAMPLES_FREERTOS_MAIN_H_
+
+namespace blinky {
+
+void init();
+static void blinkTask(void* args);
+
+}
+
+#endif /* STM32_CMAKE_EXAMPLES_FREERTOS_MAIN_H_ */

--- a/examples/freertos/stm32f4xx_hal_conf.h
+++ b/examples/freertos/stm32f4xx_hal_conf.h
@@ -37,7 +37,7 @@
 #define HAL_MODULE_ENABLED  
 // #define HAL_ADC_MODULE_ENABLED
 // #define HAL_CAN_MODULE_ENABLED
-/* #define HAL_CAN_LEGACY_MODULE_ENABLED */
+// #define HAL_CAN_LEGACY_MODULE_ENABLED
 // #define HAL_CRC_MODULE_ENABLED
 // #define HAL_CEC_MODULE_ENABLED
 // #define HAL_CRYP_MODULE_ENABLED
@@ -79,7 +79,6 @@
 // #define HAL_PCD_MODULE_ENABLED
 // #define HAL_HCD_MODULE_ENABLED
 // #define HAL_FMPI2C_MODULE_ENABLED
-// #define HAL_FMPSMBUS_MODULE_ENABLED
 // #define HAL_SPDIFRX_MODULE_ENABLED
 // #define HAL_DFSDM_MODULE_ENABLED
 // #define HAL_LPTIM_MODULE_ENABLED
@@ -164,7 +163,6 @@
 #define  USE_HAL_HCD_REGISTER_CALLBACKS         0U /* HCD register callback disabled       */
 #define  USE_HAL_I2C_REGISTER_CALLBACKS         0U /* I2C register callback disabled       */
 #define  USE_HAL_FMPI2C_REGISTER_CALLBACKS      0U /* FMPI2C register callback disabled    */
-#define  USE_HAL_FMPSMBUS_REGISTER_CALLBACKS    0U /* FMPSMBUS register callback disabled  */
 #define  USE_HAL_I2S_REGISTER_CALLBACKS         0U /* I2S register callback disabled       */
 #define  USE_HAL_IRDA_REGISTER_CALLBACKS        0U /* IRDA register callback disabled      */
 #define  USE_HAL_LPTIM_REGISTER_CALLBACKS       0U /* LPTIM register callback disabled     */
@@ -452,10 +450,6 @@
 #ifdef HAL_FMPI2C_MODULE_ENABLED
  #include "stm32f4xx_hal_fmpi2c.h"
 #endif /* HAL_FMPI2C_MODULE_ENABLED */
-
-#ifdef HAL_FMPSMBUS_MODULE_ENABLED
- #include "stm32f4xx_hal_fmpsmbus.h"
-#endif /* HAL_FMPSMBUS_MODULE_ENABLED */
 
 #ifdef HAL_SPDIFRX_MODULE_ENABLED
  #include "stm32f4xx_hal_spdifrx.h"

--- a/examples/freertos/stm32h7xx_hal_conf.h
+++ b/examples/freertos/stm32h7xx_hal_conf.h
@@ -1,0 +1,432 @@
+/**
+  ******************************************************************************
+  * @file    stm32h7xx_hal_conf.h
+  * @author  MCD Application Team
+  * @brief   HAL configuration file. 
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32H7xx_HAL_CONF_H
+#define __STM32H7xx_HAL_CONF_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/* ########################## Module Selection ############################## */
+/**
+  * @brief This is the list of modules to be used in the HAL driver 
+  */
+ #define HAL_MODULE_ENABLED
+ #define HAL_ADC_MODULE_ENABLED
+/* #define HAL_CEC_MODULE_ENABLED */
+/* #define HAL_COMP_MODULE_ENABLED */
+ #define HAL_CORTEX_MODULE_ENABLED 
+/* #define HAL_CRC_MODULE_ENABLED */
+/* #define HAL_CRYP_MODULE_ENABLED */
+/* #define HAL_DAC_MODULE_ENABLED */
+/* #define HAL_DCMI_MODULE_ENABLED */
+/* #define HAL_DFSDM_MODULE_ENABLED */
+#define HAL_DMA_MODULE_ENABLED
+#define HAL_DMA2D_MODULE_ENABLED
+#define HAL_ETH_MODULE_ENABLED
+#define HAL_EXTI_MODULE_ENABLED
+/* #define HAL_FDCAN_MODULE_ENABLED */
+#define HAL_FLASH_MODULE_ENABLED
+#define HAL_GPIO_MODULE_ENABLED
+/* #define HAL_HASH_MODULE_ENABLED */
+/* #define HAL_HCD_MODULE_ENABLED */
+/* #define HAL_HRTIM_MODULE_ENABLED */
+/* #define HAL_HSEM_MODULE_ENABLED */
+#define HAL_I2C_MODULE_ENABLED
+/* #define HAL_I2S_MODULE_ENABLED */
+/* #define HAL_IRDA_MODULE_ENABLED */
+/* #define HAL_IWDG_MODULE_ENABLED */
+/* #define HAL_JPEG_MODULE_ENABLED */
+/* #define HAL_LPTIM_MODULE_ENABLED */
+#define HAL_LTDC_MODULE_ENABLED
+/* #define HAL_MDIOS_MODULE_ENABLED */
+#define HAL_MDMA_MODULE_ENABLED
+/* #define HAL_MMC_MODULE_ENABLED */
+/* #define HAL_NAND_MODULE_ENABLED */
+/* #define HAL_NOR_MODULE_ENABLED */
+/* #define HAL_OPAMP_MODULE_ENABLED */
+/* #define HAL_PCD_MODULE_ENABLED */
+#define HAL_PWR_MODULE_ENABLED
+/* #define HAL_QSPI_MODULE_ENABLED */
+/* #define HAL_RAMECC_MODULE_ENABLED */  
+#define HAL_RCC_MODULE_ENABLED
+/* #define HAL_RNG_MODULE_ENABLED */
+/* #define HAL_RTC_MODULE_ENABLED */
+/* #define HAL_SAI_MODULE_ENABLED */
+/* #define HAL_SD_MODULE_ENABLED */
+#define HAL_SDRAM_MODULE_ENABLED
+/* #define HAL_SMARTCARD_MODULE_ENABLED */
+/* #define HAL_SMBUS_MODULE_ENABLED */
+/* #define HAL_SPDIFRX_MODULE_ENABLED */
+/* #define HAL_SPI_MODULE_ENABLED */
+/* #define HAL_SRAM_MODULE_ENABLED */
+/* #define HAL_SWPMI_MODULE_ENABLED */
+#define HAL_TIM_MODULE_ENABLED
+#define HAL_UART_MODULE_ENABLED
+/* #define HAL_USART_MODULE_ENABLED */
+/* #define HAL_WWDG_MODULE_ENABLED */
+
+/* ########################## Oscillator Values adaptation ####################*/
+/**
+  * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSE is used as system clock source, directly or through the PLL).  
+  */
+#if !defined  (HSE_VALUE) 
+#define HSE_VALUE    ((uint32_t)25000000) /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
+
+#if !defined  (HSE_STARTUP_TIMEOUT)
+  #define HSE_STARTUP_TIMEOUT    ((uint32_t)100)   /*!< Time out for HSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
+
+/**
+  * @brief Internal  oscillator (CSI) default value.
+  *        This value is the default CSI value after Reset.
+  */
+#if !defined  (CSI_VALUE)
+  #define CSI_VALUE    ((uint32_t)4000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* CSI_VALUE */
+   
+/**
+  * @brief Internal High Speed oscillator (HSI) value.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSI is used as system clock source, directly or through the PLL). 
+  */
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE    ((uint32_t)64000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
+
+/**
+  * @brief External Low Speed oscillator (LSE) value.
+  *        This value is used by the UART, RTC HAL module to compute the system frequency
+  */
+#if !defined  (LSE_VALUE)
+  #define LSE_VALUE    ((uint32_t)32768) /*!< Value of the External oscillator in Hz*/
+#endif /* LSE_VALUE */
+
+   
+#if !defined  (LSE_STARTUP_TIMEOUT)
+  #define LSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for LSE start up, in ms */
+#endif /* LSE_STARTUP_TIMEOUT */
+
+#if !defined  (LSI_VALUE) 
+  #define LSI_VALUE  ((uint32_t)32000)      /*!< LSI Typical Value in Hz*/
+#endif /* LSI_VALUE */                      /*!< Value of the Internal Low Speed oscillator in Hz
+                                              The real value may vary depending on the variations
+                                              in voltage and temperature.*/
+
+/**
+  * @brief External clock source for I2S peripheral
+  *        This value is used by the I2S HAL module to compute the I2S clock source 
+  *        frequency, this source is inserted directly through I2S_CKIN pad. 
+  */
+#if !defined  (EXTERNAL_CLOCK_VALUE)
+  #define EXTERNAL_CLOCK_VALUE    12288000U /*!< Value of the External clock in Hz*/
+#endif /* EXTERNAL_CLOCK_VALUE */
+
+/* Tip: To avoid modifying this file each time you need to use different HSE,
+   ===  you can define the HSE value in your toolchain compiler preprocessor. */
+
+/* ########################### System Configuration ######################### */
+/**
+  * @brief This is the HAL system configuration section
+  */     
+#define  VDD_VALUE                    3300UL /*!< Value of VDD in mv */
+#define  TICK_INT_PRIORITY            ((uint32_t)0x0F) /*!< tick interrupt priority */
+#define  USE_RTOS                     0
+#define  USE_SD_TRANSCEIVER           1U               /*!< use uSD Transceiver */
+   
+/* ########################### Ethernet Configuration ######################### */
+#define ETH_TX_DESC_CNT         4  /* number of Ethernet Tx DMA descriptors */
+#define ETH_RX_DESC_CNT         4  /* number of Ethernet Rx DMA descriptors */
+   
+#define ETH_MAC_ADDR0    ((uint8_t)0x02)
+#define ETH_MAC_ADDR1    ((uint8_t)0x00)
+#define ETH_MAC_ADDR2    ((uint8_t)0x00)
+#define ETH_MAC_ADDR3    ((uint8_t)0x00)
+#define ETH_MAC_ADDR4    ((uint8_t)0x00)
+#define ETH_MAC_ADDR5    ((uint8_t)0x00)
+
+/* ########################## Assert Selection ############################## */
+/**
+  * @brief Uncomment the line below to expanse the "assert_param" macro in the 
+  *        HAL drivers code
+  */
+/* #define USE_FULL_ASSERT    1 */
+
+
+/* ################## SPI peripheral configuration ########################## */
+/** 
+  * @brief Used to activate CRC feature inside HAL SPI Driver
+  *        Activated   (1U): CRC code is compiled within HAL SPI driver
+  *        Deactivated (0U): CRC code excluded from HAL SPI driver
+  */
+
+#define USE_SPI_CRC                   1U
+
+
+/* Includes ------------------------------------------------------------------*/
+/**
+  * @brief Include module's header file 
+  */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+  #include "stm32h7xx_hal_rcc.h"
+#endif /* HAL_RCC_MODULE_ENABLED */
+
+#ifdef HAL_GPIO_MODULE_ENABLED
+  #include "stm32h7xx_hal_gpio.h"
+#endif /* HAL_GPIO_MODULE_ENABLED */
+
+#ifdef HAL_DMA_MODULE_ENABLED
+  #include "stm32h7xx_hal_dma.h"
+#endif /* HAL_DMA_MODULE_ENABLED */
+
+#ifdef HAL_MDMA_MODULE_ENABLED
+ #include "stm32h7xx_hal_mdma.h"
+#endif /* HAL_MDMA_MODULE_ENABLED */
+
+#ifdef HAL_HASH_MODULE_ENABLED
+  #include "stm32h7xx_hal_hash.h"
+#endif /* HAL_HASH_MODULE_ENABLED */
+
+#ifdef HAL_DCMI_MODULE_ENABLED
+  #include "stm32h7xx_hal_dcmi.h"
+#endif /* HAL_DCMI_MODULE_ENABLED */
+
+#ifdef HAL_DMA2D_MODULE_ENABLED
+  #include "stm32h7xx_hal_dma2d.h"
+#endif /* HAL_DMA2D_MODULE_ENABLED */
+
+#ifdef HAL_DFSDM_MODULE_ENABLED
+  #include "stm32h7xx_hal_dfsdm.h"
+#endif /* HAL_DFSDM_MODULE_ENABLED */
+
+#ifdef HAL_ETH_MODULE_ENABLED
+  #include "stm32h7xx_hal_eth.h"
+#endif /* HAL_ETH_MODULE_ENABLED */
+   
+#ifdef HAL_EXTI_MODULE_ENABLED
+  #include "stm32h7xx_hal_exti.h"
+#endif /* HAL_EXTI_MODULE_ENABLED */
+
+#ifdef HAL_CORTEX_MODULE_ENABLED
+  #include "stm32h7xx_hal_cortex.h"
+#endif /* HAL_CORTEX_MODULE_ENABLED */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+  #include "stm32h7xx_hal_adc.h"
+#endif /* HAL_ADC_MODULE_ENABLED */
+
+#ifdef HAL_FDCAN_MODULE_ENABLED
+  #include "stm32h7xx_hal_fdcan.h"
+#endif /* HAL_FDCAN_MODULE_ENABLED */
+
+#ifdef HAL_CEC_MODULE_ENABLED
+  #include "stm32h7xx_hal_cec.h"
+#endif /* HAL_CEC_MODULE_ENABLED */
+
+#ifdef HAL_COMP_MODULE_ENABLED
+  #include "stm32h7xx_hal_comp.h"
+#endif /* HAL_COMP_MODULE_ENABLED */
+
+#ifdef HAL_CRC_MODULE_ENABLED
+  #include "stm32h7xx_hal_crc.h"
+#endif /* HAL_CRC_MODULE_ENABLED */
+
+#ifdef HAL_CRYP_MODULE_ENABLED
+  #include "stm32h7xx_hal_cryp.h" 
+#endif /* HAL_CRYP_MODULE_ENABLED */
+
+#ifdef HAL_DAC_MODULE_ENABLED
+  #include "stm32h7xx_hal_dac.h"
+#endif /* HAL_DAC_MODULE_ENABLED */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+  #include "stm32h7xx_hal_flash.h"
+#endif /* HAL_FLASH_MODULE_ENABLED */
+
+#ifdef HAL_HRTIM_MODULE_ENABLED
+  #include "stm32h7xx_hal_hrtim.h"
+#endif /* HAL_HRTIM_MODULE_ENABLED */
+
+#ifdef HAL_HSEM_MODULE_ENABLED
+  #include "stm32h7xx_hal_hsem.h"
+#endif /* HAL_HSEM_MODULE_ENABLED */
+
+#ifdef HAL_SRAM_MODULE_ENABLED
+  #include "stm32h7xx_hal_sram.h"
+#endif /* HAL_SRAM_MODULE_ENABLED */
+
+#ifdef HAL_NOR_MODULE_ENABLED
+  #include "stm32h7xx_hal_nor.h"
+#endif /* HAL_NOR_MODULE_ENABLED */
+
+#ifdef HAL_NAND_MODULE_ENABLED
+  #include "stm32h7xx_hal_nand.h"
+#endif /* HAL_NAND_MODULE_ENABLED */
+      
+#ifdef HAL_I2C_MODULE_ENABLED
+ #include "stm32h7xx_hal_i2c.h"
+#endif /* HAL_I2C_MODULE_ENABLED */
+
+#ifdef HAL_I2S_MODULE_ENABLED
+ #include "stm32h7xx_hal_i2s.h"
+#endif /* HAL_I2S_MODULE_ENABLED */
+
+#ifdef HAL_IWDG_MODULE_ENABLED
+ #include "stm32h7xx_hal_iwdg.h"
+#endif /* HAL_IWDG_MODULE_ENABLED */
+
+#ifdef HAL_JPEG_MODULE_ENABLED
+ #include "stm32h7xx_hal_jpeg.h"
+#endif /* HAL_JPEG_MODULE_ENABLED */
+
+#ifdef HAL_MDIOS_MODULE_ENABLED
+ #include "stm32h7xx_hal_mdios.h"
+#endif /* HAL_MDIOS_MODULE_ENABLED */
+
+
+#ifdef HAL_MMC_MODULE_ENABLED
+ #include "stm32h7xx_hal_mmc.h"
+#endif /* HAL_MMC_MODULE_ENABLED */
+   
+#ifdef HAL_LPTIM_MODULE_ENABLED
+#include "stm32h7xx_hal_lptim.h"
+#endif /* HAL_LPTIM_MODULE_ENABLED */
+
+#ifdef HAL_LTDC_MODULE_ENABLED
+#include "stm32h7xx_hal_ltdc.h"
+#endif /* HAL_LTDC_MODULE_ENABLED */
+
+#ifdef HAL_OPAMP_MODULE_ENABLED
+#include "stm32h7xx_hal_opamp.h"
+#endif /* HAL_OPAMP_MODULE_ENABLED */
+   
+#ifdef HAL_PWR_MODULE_ENABLED
+ #include "stm32h7xx_hal_pwr.h"
+#endif /* HAL_PWR_MODULE_ENABLED */
+
+#ifdef HAL_QSPI_MODULE_ENABLED
+ #include "stm32h7xx_hal_qspi.h"
+#endif /* HAL_QSPI_MODULE_ENABLED */
+
+#ifdef HAL_RAMECC_MODULE_ENABLED
+ #include "stm32h7xx_hal_ramecc.h"
+#endif /* HAL_HCD_MODULE_ENABLED */
+   
+#ifdef HAL_RNG_MODULE_ENABLED
+ #include "stm32h7xx_hal_rng.h"
+#endif /* HAL_RNG_MODULE_ENABLED */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+ #include "stm32h7xx_hal_rtc.h"
+#endif /* HAL_RTC_MODULE_ENABLED */
+
+#ifdef HAL_SAI_MODULE_ENABLED
+ #include "stm32h7xx_hal_sai.h"
+#endif /* HAL_SAI_MODULE_ENABLED */
+
+#ifdef HAL_SD_MODULE_ENABLED
+ #include "stm32h7xx_hal_sd.h"
+#endif /* HAL_SD_MODULE_ENABLED */
+
+#ifdef HAL_SDRAM_MODULE_ENABLED
+ #include "stm32h7xx_hal_sdram.h"
+#endif /* HAL_SDRAM_MODULE_ENABLED */
+   
+#ifdef HAL_SPI_MODULE_ENABLED
+ #include "stm32h7xx_hal_spi.h"
+#endif /* HAL_SPI_MODULE_ENABLED */
+
+#ifdef HAL_SPDIFRX_MODULE_ENABLED
+ #include "stm32h7xx_hal_spdifrx.h"
+#endif /* HAL_SPDIFRX_MODULE_ENABLED */
+
+#ifdef HAL_SWPMI_MODULE_ENABLED
+ #include "stm32h7xx_hal_swpmi.h"
+#endif /* HAL_SWPMI_MODULE_ENABLED */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+ #include "stm32h7xx_hal_tim.h"
+#endif /* HAL_TIM_MODULE_ENABLED */
+
+#ifdef HAL_UART_MODULE_ENABLED
+ #include "stm32h7xx_hal_uart.h"
+#endif /* HAL_UART_MODULE_ENABLED */
+
+#ifdef HAL_USART_MODULE_ENABLED
+ #include "stm32h7xx_hal_usart.h"
+#endif /* HAL_USART_MODULE_ENABLED */
+
+#ifdef HAL_IRDA_MODULE_ENABLED
+ #include "stm32h7xx_hal_irda.h"
+#endif /* HAL_IRDA_MODULE_ENABLED */
+
+#ifdef HAL_SMARTCARD_MODULE_ENABLED
+ #include "stm32h7xx_hal_smartcard.h"
+#endif /* HAL_SMARTCARD_MODULE_ENABLED */
+
+#ifdef HAL_SMBUS_MODULE_ENABLED
+ #include "stm32h7xx_hal_smbus.h"
+#endif /* HAL_SMBUS_MODULE_ENABLED */
+
+#ifdef HAL_WWDG_MODULE_ENABLED
+ #include "stm32h7xx_hal_wwdg.h"
+#endif /* HAL_WWDG_MODULE_ENABLED */
+   
+#ifdef HAL_PCD_MODULE_ENABLED
+ #include "stm32h7xx_hal_pcd.h"
+#endif /* HAL_PCD_MODULE_ENABLED */
+
+#ifdef HAL_HCD_MODULE_ENABLED
+ #include "stm32h7xx_hal_hcd.h"
+#endif /* HAL_HCD_MODULE_ENABLED */
+   
+/* Exported macro ------------------------------------------------------------*/
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  The assert_param macro is used for function's parameters check.
+  * @param  expr: If expr is false, it calls assert_failed function
+  *         which reports the name of the source file and the source
+  *         line number of the call that failed. 
+  *         If expr is true, it returns no value.
+  * @retval None
+  */
+  #define assert_param(expr) ((expr) ? (void)0U : assert_failed((uint8_t *)__FILE__, __LINE__))
+/* Exported functions ------------------------------------------------------- */
+  void assert_failed(uint8_t* file, uint32_t line);
+#else
+  #define assert_param(expr) ((void)0U)
+#endif /* USE_FULL_ASSERT */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32H7xx_HAL_CONF_H */
+ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
Full discussion and review can be found here: https://github.com/ObKo/stm32-cmake/pull/227 . This is the squashed version of the feature for a cleaner history and with a proper git commit for the PR.

This branch has the complete feature set for CMSIS RTOS support.
Builds on #190 and #189 , a lot of work provided by @g-arjones , extended with documentation and an updated `freertos` example with the same architetecture as #225

Closes #227 
Closes #188 . Closes #160 issues
Closes #190 Closes #189 PR

The updated `freertos` example can now be compiled with CMSIS RTOS by passing `-DUSE_CMSIS_RTOS=ON` and CMSIS RTOSV2 by passing `-DUSE_CMSIS_RTOS_V2=ON` . When doing this, it is not necessary to set `FREERTOS_PATH` anymore, because the build system can use the FreeRTOS and CMSIS RTOS sources inside the Cube repository. See updated README for more details