### PR TITLE
find_package(freeRTOS) for cortex M33 

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ device family also has to be specified as a component for the `FreeRTOS` package
 
 CMSIS RTOS can be used by specifying a `CMSIS` target and by finding the CMSIS `RTOS` package.
 The following section will show a few example configurations for the H7 and F4 family.
-You can also find example code for the `H743ZI` and `F407VG` devices in the `examples`
+You can also find example code for several devices in the [examples](https://github.com/ObKo/stm32-cmake/tree/master/examples/freertos)
 folder.
 
 Typical usage for a H7 device when using the M7 core, using an external kernel without CMSIS
@@ -247,6 +247,30 @@ find_package(FreeRTOS COMPONENTS ARM_CM4F REQUIRED)
 target_link_libraries(${TARGET_NAME} PRIVATE
     ...
     FreeRTOS::ARM_CM4F
+)
+```
+
+For ARMv8-M architecture (CM23 and CM33) you can choose "No Trust Zone" port:
+
+```cmake
+find_package(FreeRTOS COMPONENTS ARM_CM33_NTZ REQUIRED)
+target_link_libraries(${TARGET_NAME} PRIVATE
+    ...
+    FreeRTOS::ARM_CM33_NTZ
+)
+```
+
+Or you can use the trust zone with:
+
+```cmake
+find_package(FreeRTOS COMPONENTS ARM_CM33 REQUIRED)
+target_link_libraries(${SECURE_TARGET_NAME} PRIVATE
+    ...
+    FreeRTOS::ARM_CM33::SECURE
+)
+target_link_libraries(${NON_SECURE_TARGET_NAME} PRIVATE
+    ...
+    FreeRTOS::ARM_CM33::NON_SECURE
 )
 ```
 
@@ -277,8 +301,9 @@ in the Cube repository
 For the multi-core architectures, both family and core need to be specified like shown in the
 example above.
 
-The following FreeRTOS ports are supported in general: `ARM_CM0`, `ARM_CM3`, `ARM_CM4F`, `ARM_CM7`,
-`ARM_CM3_MPU`, `ARM_CM4_MPU`, `ARM_CM7_MPU`.
+The following FreeRTOS ports are supported in general: `ARM_CM0`, `ARM_CM3`,
+`ARM_CM3_MPU`, `ARM_CM4F`, `ARM_CM4_MPU`, `ARM_CM7`, `ARM_CM7_MPU`, 
+`ARM_CM23`, `ARM_CM23_NTZ`, `ARM_CM33`, `ARM_CM33_NTZ`.
 
 Other FreeRTOS libraries, with `FREERTOS_NAMESPACE` being set as specified in the examples above:
 

--- a/cmake/FindFreeRTOS.cmake
+++ b/cmake/FindFreeRTOS.cmake
@@ -155,6 +155,16 @@ macro(stm32_find_freertos FreeRTOS_NAMESPACE FREERTOS_PATH)
             target_sources(${FreeRTOS_NAMESPACE}::${PORT} INTERFACE "${FreeRTOS_${PORT}_SOURCE}")
             target_include_directories(${FreeRTOS_NAMESPACE}::${PORT} INTERFACE "${FreeRTOS_${PORT}_PATH}")
         endif()
+
+        # armv8-m needs additional file even if using "No Trust Zone" port
+        if(${PORT} STREQUAL ARM_CM23_NTZ OR ${PORT} STREQUAL ARM_CM33_NTZ)
+            find_file(FreeRTOS_${PORT}_ASM
+                NAMES portasm.c
+                PATHS "${FreeRTOS_${PORT}_PATH}"
+                NO_DEFAULT_PATH
+            )
+            target_sources(${FreeRTOS_NAMESPACE}::${PORT} INTERFACE "${FreeRTOS_${PORT}_ASM}")
+        endif()
         
         if(FreeRTOS_${PORT}_PATH AND 
            FreeRTOS_${PORT}_SOURCE AND 

--- a/cmake/FindFreeRTOS.cmake
+++ b/cmake/FindFreeRTOS.cmake
@@ -1,5 +1,7 @@
 # For information about why and how of this file: https://cmake.org/cmake/help/latest/command/find_package.html
 set(FreeRTOS_PORTS ARM_CM0 ARM_CM3 ARM_CM3_MPU ARM_CM4_MPU ARM_CM4F ARM_CM7 ARM_CM7_MPU ARM_CM23 ARM_CM23_NTZ ARM_CM33 ARM_CM33_NTZ)
+set(FreeRTOS_armv8_PORTS ARM_CM23_NTZ ARM_CM33_NTZ ARM_CM23 ARM_CM33)
+set(FreeRTOS_armv8_trustZone_PORTS ARM_CM23 ARM_CM33)
 
 if(NOT FreeRTOS_FIND_COMPONENTS)
     set(FreeRTOS_FIND_COMPONENTS ${FreeRTOS_PORTS})
@@ -125,7 +127,7 @@ macro(stm32_find_freertos FreeRTOS_NAMESPACE FREERTOS_PATH)
     endforeach()
 
     foreach(PORT ${FreeRTOS_FIND_COMPONENTS_PORTS})
-        if(${PORT} STREQUAL ARM_CM23 OR ${PORT} STREQUAL ARM_CM33)
+        if(${PORT} IN_LIST FreeRTOS_armv8_trustZone_PORTS)
             set(ARMv8_NON_SECURE "::NON_SECURE")
         endif()
         
@@ -161,11 +163,11 @@ macro(stm32_find_freertos FreeRTOS_NAMESPACE FREERTOS_PATH)
             message(trace "FindFreeRTOS: creating target ${FreeRTOS_NAMESPACE}::${PORT}${ARMv8_NON_SECURE}")
             
             # armv8-m needs additional file even if using "No Trust Zone" port
-            if(${PORT} STREQUAL ARM_CM23_NTZ OR ${PORT} STREQUAL ARM_CM33_NTZ OR ${PORT} STREQUAL ARM_CM23 OR ${PORT} STREQUAL ARM_CM33)
+            if(${PORT} IN_LIST FreeRTOS_armv8_PORTS)
                 target_sources(${FreeRTOS_NAMESPACE}::${PORT}${ARMv8_NON_SECURE} INTERFACE "${FreeRTOS_${PORT}_PATH}/portasm.c")
             endif()
 
-            if(${PORT} STREQUAL ARM_CM23 OR ${PORT} STREQUAL ARM_CM33)
+            if(${PORT} IN_LIST FreeRTOS_armv8_trustZone_PORTS)
                 # create the secure target
                 add_library(${FreeRTOS_NAMESPACE}::${PORT}::SECURE INTERFACE IMPORTED)
                 # ::SECURE doesn't link FreeRTOS like ::NON_SECURE does

--- a/cmake/FindFreeRTOS.cmake
+++ b/cmake/FindFreeRTOS.cmake
@@ -1,5 +1,5 @@
 # For information about why and how of this file: https://cmake.org/cmake/help/latest/command/find_package.html
-set(FreeRTOS_PORTS ARM_CM0 ARM_CM3 ARM_CM4F ARM_CM7 ARM_CM4_MPU ARM_CM3_MPU ARM_CM7_MPU)
+set(FreeRTOS_PORTS ARM_CM0 ARM_CM3 ARM_CM3_MPU ARM_CM4_MPU ARM_CM4F ARM_CM7 ARM_CM7_MPU ARM_CM23_NTZ ARM_CM33_NTZ)
 
 if(NOT FreeRTOS_FIND_COMPONENTS)
     set(FreeRTOS_FIND_COMPONENTS ${FreeRTOS_PORTS})
@@ -129,10 +129,12 @@ macro(stm32_find_freertos FreeRTOS_NAMESPACE FREERTOS_PATH)
             NAMES portmacro.h
             PATHS "${FREERTOS_PATH}" "${FREERTOS_PATH}/FreeRTOS" 
             PATH_SUFFIXES
-                "portable/GCC/${PORT}/r0p1"
                 "portable/GCC/${PORT}"
+                "portable/GCC/${PORT}/r0p1"
+                "portable/GCC/${PORT}/non_secure"
                 "Source/portable/GCC/${PORT}"
                 "Source/portable/GCC/${PORT}/r0p1"
+                "Source/portable/GCC/${PORT}/non_secure"
             NO_DEFAULT_PATH
         )
 

--- a/cmake/FindFreeRTOS.cmake
+++ b/cmake/FindFreeRTOS.cmake
@@ -1,5 +1,5 @@
 # For information about why and how of this file: https://cmake.org/cmake/help/latest/command/find_package.html
-set(FreeRTOS_PORTS ARM_CM0 ARM_CM3 ARM_CM3_MPU ARM_CM4_MPU ARM_CM4F ARM_CM7 ARM_CM7_MPU ARM_CM23_NTZ ARM_CM33_NTZ)
+set(FreeRTOS_PORTS ARM_CM0 ARM_CM3 ARM_CM3_MPU ARM_CM4_MPU ARM_CM4F ARM_CM7 ARM_CM7_MPU ARM_CM23 ARM_CM23_NTZ ARM_CM33 ARM_CM33_NTZ)
 
 if(NOT FreeRTOS_FIND_COMPONENTS)
     set(FreeRTOS_FIND_COMPONENTS ${FreeRTOS_PORTS})
@@ -125,6 +125,10 @@ macro(stm32_find_freertos FreeRTOS_NAMESPACE FREERTOS_PATH)
     endforeach()
 
     foreach(PORT ${FreeRTOS_FIND_COMPONENTS_PORTS})
+        if(${PORT} STREQUAL ARM_CM23 OR ${PORT} STREQUAL ARM_CM33)
+            set(ARMv8_NON_SECURE "::NON_SECURE")
+        endif()
+        
         find_path(FreeRTOS_${PORT}_PATH
             NAMES portmacro.h
             PATHS "${FREERTOS_PATH}" "${FREERTOS_PATH}/FreeRTOS" 
@@ -149,21 +153,34 @@ macro(stm32_find_freertos FreeRTOS_NAMESPACE FREERTOS_PATH)
             PATHS "${FreeRTOS_${PORT}_PATH}"
             NO_DEFAULT_PATH
         )
-        if(NOT (TARGET ${FreeRTOS_NAMESPACE}::${PORT}))
-            add_library(${FreeRTOS_NAMESPACE}::${PORT} INTERFACE IMPORTED)
-            target_link_libraries(${FreeRTOS_NAMESPACE}::${PORT} INTERFACE FreeRTOS)
-            target_sources(${FreeRTOS_NAMESPACE}::${PORT} INTERFACE "${FreeRTOS_${PORT}_SOURCE}")
-            target_include_directories(${FreeRTOS_NAMESPACE}::${PORT} INTERFACE "${FreeRTOS_${PORT}_PATH}")
-        endif()
+        if(NOT (TARGET ${FreeRTOS_NAMESPACE}::${PORT}${ARMv8_NON_SECURE}))
+            add_library(${FreeRTOS_NAMESPACE}::${PORT}${ARMv8_NON_SECURE} INTERFACE IMPORTED)
+            target_link_libraries(${FreeRTOS_NAMESPACE}::${PORT}${ARMv8_NON_SECURE} INTERFACE FreeRTOS)
+            target_sources(${FreeRTOS_NAMESPACE}::${PORT}${ARMv8_NON_SECURE} INTERFACE "${FreeRTOS_${PORT}_SOURCE}")
+            target_include_directories(${FreeRTOS_NAMESPACE}::${PORT}${ARMv8_NON_SECURE} INTERFACE "${FreeRTOS_${PORT}_PATH}")
+            message(trace "FindFreeRTOS: creating target ${FreeRTOS_NAMESPACE}::${PORT}${ARMv8_NON_SECURE}")
+            
+            # armv8-m needs additional file even if using "No Trust Zone" port
+            if(${PORT} STREQUAL ARM_CM23_NTZ OR ${PORT} STREQUAL ARM_CM33_NTZ OR ${PORT} STREQUAL ARM_CM23 OR ${PORT} STREQUAL ARM_CM33)
+                target_sources(${FreeRTOS_NAMESPACE}::${PORT}${ARMv8_NON_SECURE} INTERFACE "${FreeRTOS_${PORT}_PATH}/portasm.c")
+            endif()
 
-        # armv8-m needs additional file even if using "No Trust Zone" port
-        if(${PORT} STREQUAL ARM_CM23_NTZ OR ${PORT} STREQUAL ARM_CM33_NTZ)
-            find_file(FreeRTOS_${PORT}_ASM
-                NAMES portasm.c
-                PATHS "${FreeRTOS_${PORT}_PATH}"
-                NO_DEFAULT_PATH
-            )
-            target_sources(${FreeRTOS_NAMESPACE}::${PORT} INTERFACE "${FreeRTOS_${PORT}_ASM}")
+            if(${PORT} STREQUAL ARM_CM23 OR ${PORT} STREQUAL ARM_CM33)
+                # create the secure target
+                add_library(${FreeRTOS_NAMESPACE}::${PORT}::SECURE INTERFACE IMPORTED)
+                # ::SECURE doesn't link FreeRTOS like ::NON_SECURE does
+                target_sources(${FreeRTOS_NAMESPACE}::${PORT}::SECURE INTERFACE "${FreeRTOS_${PORT}_PATH}/../secure/secure_context.c"
+                                                                                "${FreeRTOS_${PORT}_PATH}/../secure/secure_context_port.c"
+                                                                                "${FreeRTOS_${PORT}_PATH}/../secure/secure_heap.c"
+                                                                                "${FreeRTOS_${PORT}_PATH}/../secure/secure_init.c")
+                message(trace "FindFreeRTOS: creating target ${FreeRTOS_NAMESPACE}::${PORT}::SECURE")
+
+                # non-secure part needs declaratation from secure includes
+                target_include_directories(${FreeRTOS_NAMESPACE}::${PORT}${ARMv8_NON_SECURE} INTERFACE "${FreeRTOS_${PORT}_PATH}/../secure")
+                # secure part needs declaratation from non-secure includes and common freeRTOS includes
+                target_include_directories(${FreeRTOS_NAMESPACE}::${PORT}::SECURE INTERFACE "${FreeRTOS_${PORT}_PATH}"
+                                                                                            "${FreeRTOS_COMMON_INCLUDE}")
+            endif()
         endif()
         
         if(FreeRTOS_${PORT}_PATH AND 

--- a/examples/freertos/CMakeLists.txt
+++ b/examples/freertos/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.16)
 set(PROJ_NAME stm32-freertos)
 set(STM32_CMAKE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 
-set(CMAKE_MESSAGE_LOG_LEVEL trace)
-
 # Please note: When using CMSIS, it is recommended to use the FreeRTOS version supplied in the 
 # Cube repository because more recent kernels might be incompatible to the CMSIS
 # implementation provided by STM
@@ -39,7 +37,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 set(SUPPORTED_BOARDS F407VG H743ZI)
 option(FREERTOS_F407VG_EXAMPLE "Compile FreeRTOS example for the F407VG board" OFF)
 option(FREERTOS_H743ZI_EXAMPLE "Compile FreeRTOS example for the H743ZI board" OFF)
-option(FREERTOS_L552ZE_EXAMPLE "Compile FreeRTOS example for the F407VG board" ON)
+option(FREERTOS_L552ZE_EXAMPLE "Compile FreeRTOS example for the L552ZE board" OFF)
 
 if(NOT FREERTOS_F407VG_EXAMPLE AND NOT FREERTOS_H743ZI_EXAMPLE AND NOT FREERTOS_L552ZE_EXAMPLE)
     message(FATAL_ERROR

--- a/examples/freertos/CMakeLists.txt
+++ b/examples/freertos/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.16)
 set(PROJ_NAME stm32-freertos)
 set(STM32_CMAKE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 
+set(CMAKE_MESSAGE_LOG_LEVEL trace)
+
 # Please note: When using CMSIS, it is recommended to use the FreeRTOS version supplied in the 
 # Cube repository because more recent kernels might be incompatible to the CMSIS
 # implementation provided by STM
@@ -37,8 +39,9 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 set(SUPPORTED_BOARDS F407VG H743ZI)
 option(FREERTOS_F407VG_EXAMPLE "Compile FreeRTOS example for the F407VG board" OFF)
 option(FREERTOS_H743ZI_EXAMPLE "Compile FreeRTOS example for the H743ZI board" OFF)
+option(FREERTOS_L552ZE_EXAMPLE "Compile FreeRTOS example for the F407VG board" ON)
 
-if(NOT FREERTOS_F407VG_EXAMPLE AND NOT FREERTOS_H743ZI_EXAMPLE)
+if(NOT FREERTOS_F407VG_EXAMPLE AND NOT FREERTOS_H743ZI_EXAMPLE AND NOT FREERTOS_L552ZE_EXAMPLE)
     message(FATAL_ERROR
         "Please select at least one target to compile by passing FREERTOS_<BOARD>_EXAMPLE=ON\n"
         "Supported boards: ${SUPPORTED_BOARDS}"
@@ -80,6 +83,19 @@ if(FREERTOS_F407VG_EXAMPLE)
         set(FREERTOS_F4_NAMESPACE ${FREERTOS_NAMESPACE}::STM32::F4)
      else()
         set(FREERTOS_F4_NAMESPACE ${FREERTOS_NAMESPACE})
+    endif()
+endif()
+
+if(FREERTOS_L552ZE_EXAMPLE)
+    list(APPEND CMSIS_COMP_LIST STM32L552ZE)
+    list(APPEND HAL_COMP_LIST STM32L552ZE)
+    list(APPEND FREERTOS_COMP_LIST ARM_CM33_NTZ)
+    if(USE_CUBE_FREERTOS)
+        # The device family needs to be supplied as a component to use the Cube FreeRTOS sources
+        list(APPEND FREERTOS_COMP_LIST STM32L5)
+        set(FREERTOS_L5_NAMESPACE ${FREERTOS_NAMESPACE}::STM32::L5)
+     else()
+        set(FREERTOS_L5_NAMESPACE ${FREERTOS_NAMESPACE})
     endif()
 endif()
 
@@ -161,6 +177,42 @@ if(FREERTOS_F407VG_EXAMPLE)
         target_compile_definitions(${TARGET_NAME} PRIVATE
             USE_CMSIS_RTOS_V2
             CMSIS_RTOS_V2_DEVICE_HEADER="stm32f4xx_hal.h"
+        )
+    endif()
+
+    stm32_print_size_of_target(${TARGET_NAME})
+    stm32_generate_binary_file(${TARGET_NAME})
+    stm32_generate_hex_file(${TARGET_NAME})
+endif()
+
+if(FREERTOS_L552ZE_EXAMPLE)
+    set(TARGET_NAME ${PROJ_NAME}-l552ze)
+    add_executable(${TARGET_NAME})
+
+    target_sources(${TARGET_NAME} PRIVATE ${PROJECT_SOURCES})
+    target_include_directories(${TARGET_NAME} PRIVATE ${INCLUDE_DIRS})
+    target_link_libraries(${TARGET_NAME} PRIVATE
+        ${FREERTOS_L5_NAMESPACE}::Timers
+        ${FREERTOS_L5_NAMESPACE}::Heap::1
+        ${FREERTOS_L5_NAMESPACE}::ARM_CM33_NTZ
+        HAL::STM32::L5::RCC
+        HAL::STM32::L5::GPIO
+        HAL::STM32::L5::CORTEX
+        CMSIS::STM32::L552ZE
+        STM32::NoSys
+    )
+    if(USE_CMSIS_RTOS)
+        target_link_libraries(${TARGET_NAME} PRIVATE
+            CMSIS::STM32::L5::RTOS
+        )
+    endif()
+    if(USE_CMSIS_RTOS_V2)
+        target_link_libraries(${TARGET_NAME} PRIVATE
+            CMSIS::STM32::L5::RTOS_V2
+        )
+        target_compile_definitions(${TARGET_NAME} PRIVATE
+            USE_CMSIS_RTOS_V2
+            CMSIS_RTOS_V2_DEVICE_HEADER="stm32l5xx_hal.h"
         )
     endif()
 

--- a/examples/freertos/FreeRTOSConfig.h
+++ b/examples/freertos/FreeRTOSConfig.h
@@ -44,6 +44,13 @@
 #include <stdint.h>
 extern uint32_t SystemCoreClock;
 
+#if defined STM32L5
+	#define configENABLE_TRUSTZONE                   0
+	#define configRUN_FREERTOS_SECURE_ONLY           0
+	#define configENABLE_FPU                         1
+	#define configENABLE_MPU                         0
+#endif
+
 #define configUSE_PREEMPTION			1
 #define configUSE_IDLE_HOOK				1
 #define configUSE_TICK_HOOK				1

--- a/examples/freertos/FreeRTOSConfig.h
+++ b/examples/freertos/FreeRTOSConfig.h
@@ -46,6 +46,9 @@ extern uint32_t SystemCoreClock;
 
 #if defined STM32L5
 	#define configENABLE_TRUSTZONE                   0
+	#if configENABLE_TRUSTZONE
+		#define configMINIMAL_SECURE_STACK_SIZE          ((uint16_t)1024)
+	#endif
 	#define configRUN_FREERTOS_SECURE_ONLY           0
 	#define configENABLE_FPU                         1
 	#define configENABLE_MPU                         0

--- a/examples/freertos/main.cpp
+++ b/examples/freertos/main.cpp
@@ -17,6 +17,13 @@
     #define LED_PORT                GPIOD
     #define LED_PIN                 GPIO_PIN_12
     #define LED_PORT_CLK_ENABLE     __HAL_RCC_GPIOD_CLK_ENABLE
+#elif defined STM32L5
+    #include <stm32l5xx_hal.h>
+
+    // NUCLEO-L552ZE-Q blue led - PB7
+    #define LED_PORT                GPIOB
+    #define LED_PIN                 GPIO_PIN_7
+    #define LED_PORT_CLK_ENABLE     __HAL_RCC_GPIOB_CLK_ENABLE
 #endif
 
 static void blinky::blinkTask(void *arg)

--- a/examples/freertos/stm32l5xx_hal_conf.h
+++ b/examples/freertos/stm32l5xx_hal_conf.h
@@ -1,0 +1,439 @@
+/**
+  ******************************************************************************
+  * @file    stm32l5xx_hal_conf.h
+  * @author  MCD Application Team
+  * @brief   HAL configuration template file.
+  *          This file should be copied to the application folder and renamed
+  *          to stm32l5xx_hal_conf.h.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef STM32L5xx_HAL_CONF_H
+#define STM32L5xx_HAL_CONF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/* ########################## Module Selection ############################## */
+/**
+  * @brief This is the list of modules to be used in the HAL driver
+  */
+#define HAL_MODULE_ENABLED
+#define HAL_ADC_MODULE_ENABLED
+#define HAL_COMP_MODULE_ENABLED
+#define HAL_CORTEX_MODULE_ENABLED
+#define HAL_CRC_MODULE_ENABLED
+#define HAL_CRYP_MODULE_ENABLED
+#define HAL_DAC_MODULE_ENABLED
+#define HAL_DFSDM_MODULE_ENABLED
+#define HAL_DMA_MODULE_ENABLED
+#define HAL_EXTI_MODULE_ENABLED
+#define HAL_FDCAN_MODULE_ENABLED
+#define HAL_FLASH_MODULE_ENABLED
+#define HAL_GPIO_MODULE_ENABLED
+#define HAL_GTZC_MODULE_ENABLED
+#define HAL_HASH_MODULE_ENABLED
+#define HAL_I2C_MODULE_ENABLED
+#define HAL_ICACHE_MODULE_ENABLED
+#define HAL_IRDA_MODULE_ENABLED
+#define HAL_IWDG_MODULE_ENABLED
+#define HAL_LPTIM_MODULE_ENABLED
+#define HAL_MMC_MODULE_ENABLED
+#define HAL_NAND_MODULE_ENABLED
+#define HAL_NOR_MODULE_ENABLED
+#define HAL_OPAMP_MODULE_ENABLED
+#define HAL_OSPI_MODULE_ENABLED
+#define HAL_OTFDEC_MODULE_ENABLED
+#define HAL_PCD_MODULE_ENABLED
+#define HAL_PKA_MODULE_ENABLED
+#define HAL_PWR_MODULE_ENABLED
+#define HAL_RCC_MODULE_ENABLED
+#define HAL_RNG_MODULE_ENABLED
+#define HAL_RTC_MODULE_ENABLED
+#define HAL_SAI_MODULE_ENABLED
+#define HAL_SD_MODULE_ENABLED
+#define HAL_SMARTCARD_MODULE_ENABLED
+#define HAL_SMBUS_MODULE_ENABLED
+#define HAL_SPI_MODULE_ENABLED
+#define HAL_SRAM_MODULE_ENABLED
+#define HAL_TIM_MODULE_ENABLED
+#define HAL_TSC_MODULE_ENABLED
+#define HAL_UART_MODULE_ENABLED
+#define HAL_USART_MODULE_ENABLED
+#define HAL_WWDG_MODULE_ENABLED
+
+
+/* ########################## Oscillator Values adaptation ####################*/
+/**
+  * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSE is used as system clock source, directly or through the PLL).
+  */
+#if !defined  (HSE_VALUE)
+#define HSE_VALUE          16000000UL /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
+
+#if !defined  (HSE_STARTUP_TIMEOUT)
+#define HSE_STARTUP_TIMEOUT 100UL   /*!< Time out for HSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
+
+/**
+  * @brief Internal Multiple Speed oscillator (MSI) default value.
+  *        This value is the default MSI range value after Reset.
+  */
+#if !defined  (MSI_VALUE)
+#define MSI_VALUE          4000000UL /*!< Value of the Internal oscillator in Hz*/
+#endif /* MSI_VALUE */
+
+/**
+  * @brief Internal High Speed oscillator (HSI) value.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSI is used as system clock source, directly or through the PLL).
+  */
+#if !defined  (HSI_VALUE)
+#define HSI_VALUE          16000000UL /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
+
+/**
+  * @brief Internal High Speed oscillator (HSI48) value for USB FS, SDMMC and RNG.
+  *        This internal oscillator is mainly dedicated to provide a high precision clock to
+  *        the USB peripheral by means of a special Clock Recovery System (CRS) circuitry.
+  *        When the CRS is not used, the HSI48 RC oscillator runs on it default frequency
+  *        which is subject to manufacturing process variations.
+  */
+#if !defined  (HSI48_VALUE)
+#define HSI48_VALUE        48000000UL /*!< Value of the Internal High Speed oscillator for USB FS/SDMMC/RNG in Hz.
+                                          The real value my vary depending on manufacturing process variations.*/
+#endif /* HSI48_VALUE */
+
+/**
+  * @brief Internal Low Speed oscillator (LSI) value.
+  */
+#if !defined  (LSI_VALUE)
+#define LSI_VALUE           32000UL    /*!< LSI Typical Value in Hz*/
+#endif /* LSI_VALUE */                  /*!< Value of the Internal Low Speed oscillator in Hz
+The real value may vary depending on the variations
+in voltage and temperature.*/
+/**
+  * @brief External Low Speed oscillator (LSE) value.
+  *        This value is used by the UART, RTC HAL module to compute the system frequency
+  */
+#if !defined  (LSE_VALUE)
+#define LSE_VALUE          32768UL    /*!< Value of the External oscillator in Hz*/
+#endif /* LSE_VALUE */
+
+#if !defined  (LSE_STARTUP_TIMEOUT)
+#define LSE_STARTUP_TIMEOUT 5000UL    /*!< Time out for LSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
+
+/**
+  * @brief External clock source for SAI1 peripheral
+  *        This value is used by the RCC HAL module to compute the SAI1 & SAI2 clock source
+  *        frequency.
+  */
+#if !defined  (EXTERNAL_SAI1_CLOCK_VALUE)
+#define EXTERNAL_SAI1_CLOCK_VALUE  48000UL /*!< Value of the SAI1 External clock source in Hz*/
+#endif /* EXTERNAL_SAI1_CLOCK_VALUE */
+
+/**
+  * @brief External clock source for SAI2 peripheral
+  *        This value is used by the RCC HAL module to compute the SAI1 & SAI2 clock source
+  *        frequency.
+  */
+#if !defined  (EXTERNAL_SAI2_CLOCK_VALUE)
+#define EXTERNAL_SAI2_CLOCK_VALUE   48000UL /*!< Value of the SAI2 External clock source in Hz*/
+#endif /* EXTERNAL_SAI2_CLOCK_VALUE */
+
+/* Tip: To avoid modifying this file each time you need to use different HSE,
+   ===  you can define the HSE value in your toolchain compiler preprocessor. */
+
+/* ########################### System Configuration ######################### */
+/**
+  * @brief This is the HAL system configuration section
+  */
+#define VDD_VALUE          3300UL /*!< Value of VDD in mv */
+#define TICK_INT_PRIORITY  ((1UL<<__NVIC_PRIO_BITS) - 1UL)  /*!< tick interrupt priority (lowest by default) */
+#define USE_RTOS           0U
+
+/* ########################## Assert Selection ############################## */
+/**
+  * @brief Uncomment the line below to expanse the "assert_param" macro in the
+  *        HAL drivers code
+  */
+/* #define USE_FULL_ASSERT               1U */
+
+/* ################## Register callback feature configuration ############### */
+/**
+  * @brief Set below the peripheral configuration  to "1U" to add the support
+  *        of HAL callback registration/unregistration feature for the HAL
+  *        driver(s). This allows user application to provide specific callback
+  *        functions thanks to HAL_PPP_RegisterCallback() rather than overwriting
+  *        the default weak callback functions (see each stm32l5xx_hal_ppp.h file
+  *        for possible callback identifiers defined in HAL_PPP_CallbackIDTypeDef
+  *        for each PPP peripheral).
+  */
+#define USE_HAL_ADC_REGISTER_CALLBACKS        0U
+#define USE_HAL_COMP_REGISTER_CALLBACKS       0U
+#define USE_HAL_CRYP_REGISTER_CALLBACKS       0U
+#define USE_HAL_DAC_REGISTER_CALLBACKS        0U
+#define USE_HAL_DFSDM_REGISTER_CALLBACKS      0U
+#define USE_HAL_FDCAN_REGISTER_CALLBACKS      0U
+#define USE_HAL_HASH_REGISTER_CALLBACKS       0U
+#define USE_HAL_I2C_REGISTER_CALLBACKS        0U
+#define USE_HAL_IRDA_REGISTER_CALLBACKS       0U
+#define USE_HAL_LPTIM_REGISTER_CALLBACKS      0U
+#define USE_HAL_MMC_REGISTER_CALLBACKS        0U
+#define USE_HAL_NAND_REGISTER_CALLBACKS       0U
+#define USE_HAL_NOR_REGISTER_CALLBACKS        0U
+#define USE_HAL_OPAMP_REGISTER_CALLBACKS      0U
+#define USE_HAL_OSPI_REGISTER_CALLBACKS       0U
+#define USE_HAL_OTFDEC_REGISTER_CALLBACKS     0U
+#define USE_HAL_PCD_REGISTER_CALLBACKS        0U
+#define USE_HAL_PKA_REGISTER_CALLBACKS        0U
+#define USE_HAL_RNG_REGISTER_CALLBACKS        0U
+#define USE_HAL_RTC_REGISTER_CALLBACKS        0U
+#define USE_HAL_SAI_REGISTER_CALLBACKS        0U
+#define USE_HAL_SD_REGISTER_CALLBACKS         0U
+#define USE_HAL_SMARTCARD_REGISTER_CALLBACKS  0U
+#define USE_HAL_SMBUS_REGISTER_CALLBACKS      0U
+#define USE_HAL_SPI_REGISTER_CALLBACKS        0U
+#define USE_HAL_SRAM_REGISTER_CALLBACKS       0U
+#define USE_HAL_TIM_REGISTER_CALLBACKS        0U
+#define USE_HAL_TSC_REGISTER_CALLBACKS        0U
+#define USE_HAL_UART_REGISTER_CALLBACKS       0U
+#define USE_HAL_USART_REGISTER_CALLBACKS      0U
+#define USE_HAL_WWDG_REGISTER_CALLBACKS       0U
+
+/* ################## SPI peripheral configuration ########################## */
+
+/* CRC FEATURE: Use to activate CRC feature inside HAL SPI Driver
+ * Activated: CRC code is present inside driver
+ * Deactivated: CRC code cleaned from driver
+ */
+
+#define USE_SPI_CRC                   1U
+
+/* ################## CRYP peripheral configuration ########################## */
+
+#define USE_HAL_CRYP_SUSPEND_RESUME   1U
+
+/* ################## SDMMC peripheral configuration ######################### */
+
+#define USE_SD_TRANSCEIVER            0U
+
+
+
+/* Includes ------------------------------------------------------------------*/
+/**
+  * @brief Include module's header file
+  */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+#include "stm32l5xx_hal_rcc.h"
+#endif /* HAL_RCC_MODULE_ENABLED */
+
+#ifdef HAL_GPIO_MODULE_ENABLED
+#include "stm32l5xx_hal_gpio.h"
+#endif /* HAL_GPIO_MODULE_ENABLED */
+
+#ifdef HAL_DMA_MODULE_ENABLED
+#include "stm32l5xx_hal_dma.h"
+#endif /* HAL_DMA_MODULE_ENABLED */
+
+#ifdef HAL_DFSDM_MODULE_ENABLED
+#include "stm32l5xx_hal_dfsdm.h"
+#endif /* HAL_DFSDM_MODULE_ENABLED */
+
+#ifdef HAL_CORTEX_MODULE_ENABLED
+#include "stm32l5xx_hal_cortex.h"
+#endif /* HAL_CORTEX_MODULE_ENABLED */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+#include "stm32l5xx_hal_adc.h"
+#endif /* HAL_ADC_MODULE_ENABLED */
+
+#ifdef HAL_COMP_MODULE_ENABLED
+#include "stm32l5xx_hal_comp.h"
+#endif /* HAL_COMP_MODULE_ENABLED */
+
+#ifdef HAL_CRC_MODULE_ENABLED
+#include "stm32l5xx_hal_crc.h"
+#endif /* HAL_CRC_MODULE_ENABLED */
+
+#ifdef HAL_CRYP_MODULE_ENABLED
+#include "stm32l5xx_hal_cryp.h"
+#endif /* HAL_CRYP_MODULE_ENABLED */
+
+#ifdef HAL_DAC_MODULE_ENABLED
+#include "stm32l5xx_hal_dac.h"
+#endif /* HAL_DAC_MODULE_ENABLED */
+
+#ifdef HAL_EXTI_MODULE_ENABLED
+#include "stm32l5xx_hal_exti.h"
+#endif /* HAL_EXTI_MODULE_ENABLED */
+
+#ifdef HAL_FDCAN_MODULE_ENABLED
+#include "stm32l5xx_hal_fdcan.h"
+#endif /* HAL_FDCAN_MODULE_ENABLED */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+#include "stm32l5xx_hal_flash.h"
+#endif /* HAL_FLASH_MODULE_ENABLED */
+
+#ifdef HAL_GTZC_MODULE_ENABLED
+#include "stm32l5xx_hal_gtzc.h"
+#endif /* HAL_GTZC_MODULE_ENABLED */
+
+#ifdef HAL_HASH_MODULE_ENABLED
+#include "stm32l5xx_hal_hash.h"
+#endif /* HAL_HASH_MODULE_ENABLED */
+
+#ifdef HAL_I2C_MODULE_ENABLED
+#include "stm32l5xx_hal_i2c.h"
+#endif /* HAL_I2C_MODULE_ENABLED */
+
+#ifdef HAL_ICACHE_MODULE_ENABLED
+#include "stm32l5xx_hal_icache.h"
+#endif /* HAL_ICACHE_MODULE_ENABLED */
+
+#ifdef HAL_IRDA_MODULE_ENABLED
+#include "stm32l5xx_hal_irda.h"
+#endif /* HAL_IRDA_MODULE_ENABLED */
+
+#ifdef HAL_IWDG_MODULE_ENABLED
+#include "stm32l5xx_hal_iwdg.h"
+#endif /* HAL_IWDG_MODULE_ENABLED */
+
+#ifdef HAL_LPTIM_MODULE_ENABLED
+#include "stm32l5xx_hal_lptim.h"
+#endif /* HAL_LPTIM_MODULE_ENABLED */
+
+#ifdef HAL_MMC_MODULE_ENABLED
+#include "stm32l5xx_hal_mmc.h"
+#endif /* HAL_MMC_MODULE_ENABLED */
+
+#ifdef HAL_NAND_MODULE_ENABLED
+#include "stm32l5xx_hal_nand.h"
+#endif /* HAL_NAND_MODULE_ENABLED */
+
+#ifdef HAL_NOR_MODULE_ENABLED
+#include "stm32l5xx_hal_nor.h"
+#endif /* HAL_NOR_MODULE_ENABLED */
+
+#ifdef HAL_OPAMP_MODULE_ENABLED
+#include "stm32l5xx_hal_opamp.h"
+#endif /* HAL_OPAMP_MODULE_ENABLED */
+
+#ifdef HAL_OSPI_MODULE_ENABLED
+#include "stm32l5xx_hal_ospi.h"
+#endif /* HAL_OSPI_MODULE_ENABLED */
+
+#ifdef HAL_OTFDEC_MODULE_ENABLED
+#include "stm32l5xx_hal_otfdec.h"
+#endif /* HAL_OTFDEC_MODULE_ENABLED */
+
+#ifdef HAL_PCD_MODULE_ENABLED
+#include "stm32l5xx_hal_pcd.h"
+#endif /* HAL_PCD_MODULE_ENABLED */
+
+#ifdef HAL_PKA_MODULE_ENABLED
+#include "stm32l5xx_hal_pka.h"
+#endif /* HAL_PKA_MODULE_ENABLED */
+
+#ifdef HAL_PWR_MODULE_ENABLED
+#include "stm32l5xx_hal_pwr.h"
+#endif /* HAL_PWR_MODULE_ENABLED */
+
+#ifdef HAL_RNG_MODULE_ENABLED
+#include "stm32l5xx_hal_rng.h"
+#endif /* HAL_RNG_MODULE_ENABLED */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+#include "stm32l5xx_hal_rtc.h"
+#endif /* HAL_RTC_MODULE_ENABLED */
+
+#ifdef HAL_SAI_MODULE_ENABLED
+#include "stm32l5xx_hal_sai.h"
+#endif /* HAL_SAI_MODULE_ENABLED */
+
+#ifdef HAL_SD_MODULE_ENABLED
+#include "stm32l5xx_hal_sd.h"
+#endif /* HAL_SD_MODULE_ENABLED */
+
+#ifdef HAL_SMARTCARD_MODULE_ENABLED
+#include "stm32l5xx_hal_smartcard.h"
+#endif /* HAL_SMARTCARD_MODULE_ENABLED */
+
+#ifdef HAL_SMBUS_MODULE_ENABLED
+#include "stm32l5xx_hal_smbus.h"
+#endif /* HAL_SMBUS_MODULE_ENABLED */
+
+#ifdef HAL_SPI_MODULE_ENABLED
+#include "stm32l5xx_hal_spi.h"
+#endif /* HAL_SPI_MODULE_ENABLED */
+
+#ifdef HAL_SRAM_MODULE_ENABLED
+#include "stm32l5xx_hal_sram.h"
+#endif /* HAL_SRAM_MODULE_ENABLED */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+#include "stm32l5xx_hal_tim.h"
+#endif /* HAL_TIM_MODULE_ENABLED */
+
+#ifdef HAL_TSC_MODULE_ENABLED
+#include "stm32l5xx_hal_tsc.h"
+#endif /* HAL_TSC_MODULE_ENABLED */
+
+#ifdef HAL_UART_MODULE_ENABLED
+#include "stm32l5xx_hal_uart.h"
+#endif /* HAL_UART_MODULE_ENABLED */
+
+#ifdef HAL_USART_MODULE_ENABLED
+#include "stm32l5xx_hal_usart.h"
+#endif /* HAL_USART_MODULE_ENABLED */
+
+#ifdef HAL_WWDG_MODULE_ENABLED
+#include "stm32l5xx_hal_wwdg.h"
+#endif /* HAL_WWDG_MODULE_ENABLED */
+
+/* Exported macro ------------------------------------------------------------*/
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  The assert_param macro is used for function's parameters check.
+  * @param expr If expr is false, it calls assert_failed function
+  *         which reports the name of the source file and the source
+  *         line number of the call that failed.
+  *         If expr is true, it returns no value.
+  * @retval None
+  */
+#define assert_param(expr) ((expr) ? (void)0U : assert_failed((uint8_t *)__FILE__, __LINE__))
+/* Exported functions ------------------------------------------------------- */
+void assert_failed(uint8_t *file, uint32_t line);
+#else
+#define assert_param(expr) ((void)0U)
+#endif /* USE_FULL_ASSERT */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STM32L5xx_HAL_CONF_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
#231

`ARM_CM23_NTZ` should behave like `ARM_CM4F` as there is no trust zone support
`ARM_CM23/secure` is a new target `ARM_CM23::secure`
`ARM_CM23/non_secure`  is a new target `ARM_CM23::non_secure` 

- [x] Update readme
- [x] make an example with L5 in NTZ mode
- [x] test the example 

I plan to at least test the CM33_NTZ port on an L5 nucleo
The trust zone port will likely not be fully tested