### PR TITLE
CMSIS: Search projects root directory for system_stm32xxxx.c and startup_stm32xxxxxx.s files

### DIFF
--- a/cmake/FindCMSIS.cmake
+++ b/cmake/FindCMSIS.cmake
@@ -195,7 +195,7 @@ foreach(COMP ${CMSIS_FIND_COMPONENTS_FAMILIES})
     # search for system_stm32[XX]xx.c
     find_file(CMSIS_${FAMILY}${CORE_U}_SYSTEM
         NAMES system_stm32${FAMILY_L}xx.c
-        PATHS "${CMSIS_${FAMILY}${CORE_U}_PATH}/Source/Templates"
+        PATHS "${CMSIS_${FAMILY}${CORE_U}_PATH}/Source/Templates" "${CMAKE_SOURCE_DIR}"
         NO_DEFAULT_PATH
     )
     list(APPEND CMSIS_SOURCES "${CMSIS_${FAMILY}${CORE_U}_SYSTEM}")
@@ -221,7 +221,7 @@ foreach(COMP ${CMSIS_FIND_COMPONENTS_FAMILIES})
         
         find_file(CMSIS_${FAMILY}${CORE_U}_${TYPE}_STARTUP
             NAMES startup_stm32${TYPE_L}.s startup_stm32${TYPE_L}${CORE_Ucm}.s
-            PATHS "${CMSIS_${FAMILY}${CORE_U}_PATH}/Source/Templates/gcc"
+            PATHS "${CMSIS_${FAMILY}${CORE_U}_PATH}/Source/Templates/gcc" "${CMAKE_SOURCE_DIR}"
             NO_DEFAULT_PATH
         )
         list(APPEND CMSIS_SOURCES "${CMSIS_${FAMILY}${CORE_U}_${TYPE}_STARTUP}")


### PR DESCRIPTION
This enables to use of generated projects from the STM32CubeMX.

When integrated it will allow creating *CMakeLists.txt* file like this that should work without any further modifications.
```cmake
cmake_minimum_required(VERSION 3.16)

set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/stm32_gcc.cmake)
set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
set(STM32_CUBE_G0_PATH ${CMAKE_CURRENT_SOURCE_DIR})

project(CubeMX-project C ASM)

find_package(CMSIS COMPONENTS STM32G030K8 REQUIRED)
find_package(HAL COMPONENTS STM32G0 RCC RTC GPIO CORTEX UART DMA PWR REQUIRED)
set(CMAKE_INCLUDE_CURRENT_DIR TRUE)

set(PROJECT_SOURCES
    Core/Src/dma.c
    Core/Src/gpio.c
    Core/Src/main.c
    Core/Src/rtc.c
    Core/Src/stm32g0xx_hal_msp.c
    Core/Src/stm32g0xx_it.c
    Core/Src/usart.c

    Core/Inc/dma.h
    Core/Inc/gpio.h
    Core/Inc/main.h
    Core/Inc/rtc.h
    Core/Inc/stm32g0xx_hal_conf.h
    Core/Inc/stm32g0xx_it.h
    Core/Inc/usart.h
)

include_directories(Core/Inc/)

add_executable(${PROJECT_NAME} ${PROJECT_SOURCES})

target_link_libraries(${PROJECT_NAME} CMSIS::STM32::G030K8
  STM32::NoSys
  HAL::STM32::G0::CORTEX
  HAL::STM32::G0::RCCEx
  HAL::STM32::G0::RTCEx
  HAL::STM32::G0::UARTEx
  HAL::STM32::G0::GPIO
  HAL::STM32::G0::DMA
  HAL::STM32::G0::PWREx
  )

stm32_print_size_of_target(${PROJECT_NAME})
```