### PR TITLE
FindCMSIS checks that ASM is enabled before generating ASM related targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ STM32WB is a multi-cores device even if the second core is not accessible by end
 CMSIS consists of three main components:
 
 * Family-specific headers, e.g. `stm32f4xx.h`
-* Device type-specific startup sources (e.g. `startup_stm32f407xx.s`)
-* Device-specific linker scripts which requires information about memory sizes
+* Device type-specific startup sources (e.g. `startup_stm32f407xx.s`) (if ASM language is enabled)
+* Device-specific linker scripts which requires information about memory sizes (if ASM language is enabled)
 
 stm32-cmake uses modern CMake features notably imported targets and target properties.
 Every CMSIS component is CMake's target (aka library), which defines compiler definitions, compiler flags, include dirs, sources, etc. to build and propagate them as dependencies. So in a simple use-case all you need is to link your executable with library `CMSIS::STM32::<device>`:

--- a/cmake/FindCMSIS.cmake
+++ b/cmake/FindCMSIS.cmake
@@ -219,6 +219,12 @@ foreach(COMP ${CMSIS_FIND_COMPONENTS_FAMILIES})
         string(TOLOWER ${DEVICE} DEVICE_L)
         string(TOLOWER ${TYPE} TYPE_L)
         
+        get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+        if(NOT "ASM" IN_LIST languages)
+            message(STATUS "FindCMSIS: Not generating target for startup file and linker script because ASM language is not enabled")
+            continue()
+        endif()
+
         find_file(CMSIS_${FAMILY}${CORE_U}_${TYPE}_STARTUP
             NAMES startup_stm32${TYPE_L}.s startup_stm32${TYPE_L}${CORE_Ucm}.s
             PATHS "${CMSIS_${FAMILY}${CORE_U}_PATH}/Source/Templates/gcc"


### PR DESCRIPTION
The PR #287 points out that not enabling ASM language result in corrupted state.