### PR TITLE
Replaced __WFI with active infinite loop

### DIFF
--- a/examples/blinky-ll/blinky.c
+++ b/examples/blinky-ll/blinky.c
@@ -53,8 +53,7 @@ int main(void)
     SystemCoreClockUpdate();
     SysTick_Config(SystemCoreClock / 1000);
 
-    for (;;)
-        __WFI();
+    while(1);
 
     return 0;
 }

--- a/examples/blinky/blinky.c
+++ b/examples/blinky/blinky.c
@@ -53,8 +53,7 @@ int main(void)
     // 1kHz ticks
     HAL_SYSTICK_Config(SystemCoreClock / 1000);
 
-    for (;;)
-        __WFI();
+    while(1);
 
     return 0;
 }

--- a/examples/blinky/blinky.cpp
+++ b/examples/blinky/blinky.cpp
@@ -57,8 +57,6 @@ int main(void)
     // 1kHz ticks
     HAL_SYSTICK_Config(SystemCoreClock / 1000);
 
-    for (;;)
-        __WFI();
-
+    while(1);
     return 0;
 }


### PR DESCRIPTION
In #193, it was discovered that __WFI can lead to unwanted sleep of the device.
This is the fix proposed by @atsju 