### PR TITLE
feat: added reference to system_stm32f<family>xx in CMSIS targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ STM32WB is a multi-cores device even if the second core is not accessible by end
 CMSIS consists of three main components:
 
 * Family-specific headers, e.g. `stm32f4xx.h`
+* Cortex peripheral access layer header and source, e.g. `system_stm32f4xx.[c|h]`
 * Device type-specific startup sources (e.g. `startup_stm32f407xx.s`) (if ASM language is enabled)
 * Device-specific linker scripts which requires information about memory sizes (if ASM language is enabled)
 
@@ -118,12 +119,12 @@ Every CMSIS component is CMake's target (aka library), which defines compiler de
 add_executable(stm32-template main.c)
 target_link_libraries(stm32-template CMSIS::STM32::F407VG)
 ```
-That will add include directories, startup source, linker script and compiler flags to your executable.
+That will add include directories, coretx peripheral layere files, startup source, linker script and compiler flags to your executable.
 
 CMSIS creates the following targets:
 
 * `CMSIS::STM32::<FAMILY>` (e.g. `CMSIS::STM32::F4`) - common includes, compiler flags and defines for family
-* `CMSIS::STM32::<TYPE>` (e.g. `CMSIS::STM32::F407xx`) - common startup source for device type, depends on `CMSIS::STM32::<FAMILY>`
+* `CMSIS::STM32::<TYPE>` (e.g. `CMSIS::STM32::F407xx`) - common startup source for device type and cortex peripheral access layer files, depends on `CMSIS::STM32::<FAMILY>`
 * `CMSIS::STM32::<DEVICE>` (e.g. `CMSIS::STM32::F407VG`) - linker script for device, depends on `CMSIS::STM32::<TYPE>`
 
 So, if you don't need linker script, you can link only `CMSIS::STM32::<TYPE>` library and provide your own script using `stm32_add_linker_script` function


### PR DESCRIPTION
`CMSIS::STM32::<TYPE>` adds to target the `system_stm32f<family>xx.c` file. This file is not added by the `CMSIS::STM32::<FAMILY>` target and should be noted in the readme.