### PR TITLE
Update U5 to latest STM32 Cube FW Package

### DIFF
--- a/cmake/stm32/utilities.cmake
+++ b/cmake/stm32/utilities.cmake
@@ -44,9 +44,9 @@ include(FetchContent)
 
 # A CMSIS or HAL driver can specify 'cube' as version number to indicate that the driver is taken from the Cube repository
 set(STM32_FETCH_FAMILIES       F0      F1      F2      F3      F4       F7      G0      G4      H7       L0      L1      L4      L5     MP1    U5     WB      WL    )
-set(STM32_FETCH_CUBE_VERSIONS  v1.11.2 v1.8.4  v1.9.3  v1.11.2 v1.26.1  v1.16.1 v1.4.1  v1.4.0  v1.9.0   v1.12.0 v1.10.3 v1.17.0 v1.4.0 1.5.0  v1.0.0 v1.12.0 v1.1.0)
-set(STM32_FETCH_CMSIS_VERSIONS v2.3.5  v4.3.3  v2.2.5  v2.3.5  v2.6.6   v1.2.6  v1.4.0  v1.2.1  v1.10.0  v1.9.1  v2.3.2  v1.7.1  v1.0.4 cube   v1.0.0 v1.9.0  v1.1.0)
-set(STM32_FETCH_HAL_VERSIONS   v1.7.5  v1.1.8  v1.2.7  v1.5.5  v1.7.12  v1.2.9  v1.4.1  v1.2.1  v1.10.0  v1.10.4 v1.4.4  v1.13.0 v1.0.4 cube   v1.0.0 v1.9.0  v1.1.0)
+set(STM32_FETCH_CUBE_VERSIONS  v1.11.2 v1.8.4  v1.9.3  v1.11.2 v1.26.1  v1.16.1 v1.4.1  v1.4.0  v1.9.0   v1.12.0 v1.10.3 v1.17.0 v1.4.0 1.5.0  v1.3.0 v1.12.0 v1.1.0)
+set(STM32_FETCH_CMSIS_VERSIONS v2.3.5  v4.3.3  v2.2.5  v2.3.5  v2.6.6   v1.2.6  v1.4.0  v1.2.1  v1.10.0  v1.9.1  v2.3.2  v1.7.1  v1.0.4 cube   cube v1.9.0  v1.1.0)
+set(STM32_FETCH_HAL_VERSIONS   v1.7.5  v1.1.8  v1.2.7  v1.5.5  v1.7.12  v1.2.9  v1.4.1  v1.2.1  v1.10.0  v1.10.4 v1.4.4  v1.13.0 v1.0.4 cube   cube v1.9.0  v1.1.0)
 
 FetchContent_Declare(
     STM32-CMSIS

--- a/cmake/stm32/utilities.cmake
+++ b/cmake/stm32/utilities.cmake
@@ -45,8 +45,9 @@ include(FetchContent)
 # A CMSIS or HAL driver can specify 'cube' as version number to indicate that the driver is taken from the Cube repository
 set(STM32_FETCH_FAMILIES       F0      F1      F2      F3      F4       F7      G0      G4      H7       L0      L1      L4      L5     MP1    U5     WB      WL    )
 set(STM32_FETCH_CUBE_VERSIONS  v1.11.2 v1.8.4  v1.9.3  v1.11.2 v1.26.1  v1.16.1 v1.4.1  v1.4.0  v1.9.0   v1.12.0 v1.10.3 v1.17.0 v1.4.0 1.5.0  v1.3.0 v1.12.0 v1.1.0)
-set(STM32_FETCH_CMSIS_VERSIONS v2.3.5  v4.3.3  v2.2.5  v2.3.5  v2.6.6   v1.2.6  v1.4.0  v1.2.1  v1.10.0  v1.9.1  v2.3.2  v1.7.1  v1.0.4 cube   cube v1.9.0  v1.1.0)
-set(STM32_FETCH_HAL_VERSIONS   v1.7.5  v1.1.8  v1.2.7  v1.5.5  v1.7.12  v1.2.9  v1.4.1  v1.2.1  v1.10.0  v1.10.4 v1.4.4  v1.13.0 v1.0.4 cube   cube v1.9.0  v1.1.0)
+set(STM32_FETCH_CMSIS_VERSIONS v2.3.5  v4.3.3  v2.2.5  v2.3.5  v2.6.6   v1.2.6  v1.4.0  v1.2.1  v1.10.0  v1.9.1  v2.3.2  v1.7.1  v1.0.4 cube  v1.3.0 v1.9.0  v1.1.0)
+set(STM32_FETCH_HAL_VERSIONS   v1.7.5  v1.1.8  v1.2.7  v1.5.5  v1.7.12  v1.2.9  v1.4.1  v1.2.1  v1.10.0  v1.10.4 v1.4.4  v1.13.0 v1.0.4 cube  v1.3.0 v1.9.0  v1.1.0)
+
 
 FetchContent_Declare(
     STM32-CMSIS


### PR DESCRIPTION
The latest U5 STM32 Cube FW Package is 1.3.0. The CMSIS provided by STM matches the Cube version, as does the HAL.