### PR TITLE
Add '--default-script' for SDK provided linker script

### DIFF
--- a/cmake/FindCMSIS.cmake
+++ b/cmake/FindCMSIS.cmake
@@ -106,7 +106,7 @@ function(cmsis_generate_default_linker_script FAMILY DEVICE CORE)
     endif()
     add_custom_target(CMSIS_LD_${DEVICE}${CORE_U} DEPENDS "${OUTPUT_LD_FILE}")
     add_dependencies(CMSIS::STM32::${DEVICE}${CORE_C} CMSIS_LD_${DEVICE}${CORE_U})
-    stm32_add_linker_script(CMSIS::STM32::${DEVICE}${CORE_C} INTERFACE "${OUTPUT_LD_FILE}")
+    stm32_add_default_linker_script(CMSIS::STM32::${DEVICE}${CORE_C} INTERFACE "${OUTPUT_LD_FILE}")
 endfunction() 
 
 foreach(COMP ${CMSIS_FIND_COMPONENTS_FAMILIES})

--- a/cmake/stm32/common.cmake
+++ b/cmake/stm32/common.cmake
@@ -336,7 +336,7 @@ endfunction()
 
 function(stm32_add_linker_script TARGET VISIBILITY SCRIPT)
     get_filename_component(SCRIPT "${SCRIPT}" ABSOLUTE)
-    target_link_options(${TARGET} ${VISIBILITY} -T "${SCRIPT}")
+    target_link_options(${TARGET} ${VISIBILITY} "-Wl,--script=${SCRIPT}")
 
     get_target_property(TARGET_TYPE ${TARGET} TYPE)
     if(TARGET_TYPE STREQUAL "INTERFACE_LIBRARY")
@@ -350,6 +350,24 @@ function(stm32_add_linker_script TARGET VISIBILITY SCRIPT)
         set(LINK_DEPENDS "${SCRIPT}")
     endif()
 
+    set_target_properties(${TARGET} PROPERTIES ${INTERFACE_PREFIX}LINK_DEPENDS "${LINK_DEPENDS}")
+endfunction()
+
+function(stm32_add_default_linker_script TARGET VISIBILITY SCRIPT)
+    get_filename_component(SCRIPT "${SCRIPT}" ABSOLUTE)
+    target_link_options(${TARGET} ${VISIBILITY} "-Wl,--default-script=${SCRIPT}")
+
+    get_target_property(TARGET_TYPE ${TARGET} TYPE)
+    if(TARGET_TYPE STREQUAL "INTERFACE_LIBRARY")
+        set(INTERFACE_PREFIX "INTERFACE_")
+    endif()
+
+    get_target_property(LINK_DEPENDS ${TARGET} ${INTERFACE_PREFIX}LINK_DEPENDS)
+    if(LINK_DEPENDS)
+        list(APPEND LINK_DEPENDS "${SCRIPT}")
+    else()
+        set(LINK_DEPENDS "${SCRIPT}")
+    endif()
 
     set_target_properties(${TARGET} PROPERTIES ${INTERFACE_PREFIX}LINK_DEPENDS "${LINK_DEPENDS}")
 endfunction()


### PR DESCRIPTION
I tried to make an application where I needed to change the `MEMORY` block. However, the default script that is provided by the SDK hindered me from doing this, as `stm32_add_linker_script` is using the `-T` option.

If the SDK-provided script used  `-Wl,--default-script=${SCRIPT} `instead, this wouldn't be a problem.

This pull request fixes that problem. However, I couldn't nicely fix the problem without duplicating the `stm32_add_linker_script`.

Previously, when using `stm32_add_linker_script` to define a custom linker script, the SDK provided a default linker script, that used the `-T/--script` flag, which led to conflicts when you wanted a completely new user-provided linker script.

The `--default-script` flag changes this behavior and makes it possible to derive from the SDK-provided linker script, but also enables the possibility to create a completely new linker script.

This commit adds a new internal command `stm32_add_default_linker_script` that is used internally for the `--default-script` flag, and normal users shouldn't be affected by this. Thus this should not be a breaking change if this function is used as normally intended.