### PR TITLE
Update U5 to latest Cube 1.4.0

### DIFF
--- a/cmake/stm32/utilities.cmake
+++ b/cmake/stm32/utilities.cmake
@@ -44,10 +44,10 @@ include(FetchContent)
 
 # A CMSIS or HAL driver can specify 'cube' as version number to indicate that the driver is taken from the Cube repository
 set(STM32_FETCH_FAMILIES       C0     F0      F1      F2      F3      F4       F7      G0      G4      H5      H7       L0      L1      L4      L5     MP1    U5     WB      WL    )
-set(STM32_FETCH_CUBE_VERSIONS  v1.1.0 v1.11.2 v1.8.4  v1.9.3  v1.11.2 v1.26.1  v1.16.1 v1.4.1  v1.4.0  v1.1.0  v1.9.0   v1.12.0 v1.10.3 v1.17.0 v1.4.0 1.5.0  v1.3.0 v1.12.0 v1.1.0)
-set(STM32_FETCH_CMSIS_VERSIONS v1.1.0 v2.3.5  v4.3.3  v2.2.5  v2.3.5  v2.6.6   v1.2.6  v1.4.0  v1.2.1  v1.1.0  v1.10.0  v1.9.1  v2.3.2  v1.7.1  v1.0.4 cube  v1.3.0 v1.9.0  v1.1.0)
+set(STM32_FETCH_CUBE_VERSIONS  v1.1.0 v1.11.2 v1.8.4  v1.9.3  v1.11.2 v1.26.1  v1.16.1 v1.4.1  v1.4.0  v1.1.0  v1.9.0   v1.12.0 v1.10.3 v1.17.0 v1.4.0 1.5.0  v1.4.0 v1.12.0 v1.1.0)
+set(STM32_FETCH_CMSIS_VERSIONS v1.1.0 v2.3.5  v4.3.3  v2.2.5  v2.3.5  v2.6.6   v1.2.6  v1.4.0  v1.2.1  v1.1.0  v1.10.0  v1.9.1  v2.3.2  v1.7.1  v1.0.4 cube  v1.3.1 v1.9.0  v1.1.0)
 
-set(STM32_FETCH_HAL_VERSIONS   v1.1.0 v1.7.5  v1.1.8  v1.2.7  v1.5.5  v1.7.12  v1.2.9  v1.4.1  v1.2.1  v1.1.0  v1.10.0  v1.10.4 v1.4.4  v1.13.0 v1.0.4 cube  v1.3.0 v1.9.0  v1.1.0)
+set(STM32_FETCH_HAL_VERSIONS   v1.1.0 v1.7.5  v1.1.8  v1.2.7  v1.5.5  v1.7.12  v1.2.9  v1.4.1  v1.2.1  v1.1.0  v1.10.0  v1.10.4 v1.4.4  v1.13.0 v1.0.4 cube  v1.4.0 v1.9.0  v1.1.0)
 
 
 


### PR DESCRIPTION
According to https://htmlpreview.github.io/?https://github.com/STMicroelectronics/STM32CubeU5/blob/master/Release_Notes.html the CMSIS version is 1.3.1 and the HAL is 1.4.0.