### PR TITLE
Dynamic family matrix for CI jobs

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       
     - name: Install ARM toolchain
       run: sudo apt-get install gcc-arm-none-eabi binutils-arm-none-eabi 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,11 +7,14 @@ env:
   BUILD_TYPE: Release
 
 jobs:
+  RetrieveTargetsMatrix:
+    uses: ./.github/workflows/create-matrix.yml
+
   test-ubuntu:
     runs-on: ubuntu-20.04
+    needs: RetrieveTargetsMatrix
     strategy:
-      matrix:
-        family: [C0, F0, F1, F2, F3, F4, F7, G0, G4, H5, H7, L0, L1, L4, L5, U0, U5, WB, WL, MP1]
+      matrix: ${{ fromJSON(needs.RetrieveTargetsMatrix.outputs.matrix) }}
       fail-fast: false
 
     steps:

--- a/.github/workflows/create-matrix.yml
+++ b/.github/workflows/create-matrix.yml
@@ -1,0 +1,30 @@
+name: MatrixCreator
+
+run-name: "Creates supported family matrix for other jobs"
+
+on:
+  workflow_call:
+    outputs:
+      matrix:
+        description: "Supported family for job matrixing"
+        value: ${{ jobs.CreateMatrix.outputs.matrix }}
+
+jobs:
+  CreateMatrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.create-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repo
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Create matrix
+        id: create-matrix
+        run: |
+          files=$(find cmake/stm32/ -name '*.cmake' -exec sh -c "basename {} | cut -f1 -d '.' | tr '[:lower:]' '[:upper:]'" \;  | sort)
+          deletes="COMMON DEVICES LINKER_LD"
+          for del in $deletes; do
+            files=(${files[@]/$del})
+          done
+          echo "matrix={\"family\":$(jq --compact-output --null-input '$ARGS.positional' --args -- ${files[@]})}" >> $GITHUB_OUTPUT

--- a/.github/workflows/create-matrix.yml
+++ b/.github/workflows/create-matrix.yml
@@ -19,23 +19,12 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
 
-      - name: Get uppercase no-extension ordered file names
-        id: find-files
+      - name: Create matrix
+        id: create-matrix
         run: |
-          files=$(find cmake/stm32/ -name '*.cmake' -exec sh -c "basename {} | cut -f1 -d '.' | tr '[:lower:]' '[:upper:]'" \; | sort)
-          echo "files=\"${files[@]}\"" >> $GITHUB_OUTPUT
-
-      - name: Filter out non family files
-        id: get-famillies
-        run: |
-          files=${{ steps.find-files.outputs.files }}
+          files=$(find cmake/stm32/ -name '*.cmake' -exec sh -c "basename {} | cut -f1 -d '.' | tr '[:lower:]' '[:upper:]'" \;  | sort)
           deletes="COMMON DEVICES LINKER_LD"
           for del in $deletes; do
             files=(${files[@]/$del})
           done
-          echo "files=\"${files[@]\"" >> $GITHUB_OUTPUT
-
-      - name: Create matrix
-        id: create-matrix
-        run: |
-          echo "matrix={\"family\":$(jq --compact-output --null-input '$ARGS.positional' --args -- ${{ steps.get-famillies.outputs.files }})}" >> $GITHUB_OUTPUT
+          echo "matrix={\"family\":$(jq --compact-output --null-input '$ARGS.positional' --args -- ${files[@]})}" >> $GITHUB_OUTPUT

--- a/.github/workflows/create-matrix.yml
+++ b/.github/workflows/create-matrix.yml
@@ -19,12 +19,23 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
 
-      - name: Create matrix
-        id: create-matrix
+      - name: Get uppercase no-extension ordered file names
+        id: find-files
         run: |
-          files=$(find cmake/stm32/ -name '*.cmake' -exec sh -c "basename {} | cut -f1 -d '.' | tr '[:lower:]' '[:upper:]'" \;  | sort)
+          files=$(find cmake/stm32/ -name '*.cmake' -exec sh -c "basename {} | cut -f1 -d '.' | tr '[:lower:]' '[:upper:]'" \; | sort)
+          echo "files=\"${files[@]}\"" >> $GITHUB_OUTPUT
+
+      - name: Filter out non family files
+        id: get-famillies
+        run: |
+          files=${{ steps.find-files.outputs.files }}
           deletes="COMMON DEVICES LINKER_LD"
           for del in $deletes; do
             files=(${files[@]/$del})
           done
-          echo "matrix={\"family\":$(jq --compact-output --null-input '$ARGS.positional' --args -- ${files[@]})}" >> $GITHUB_OUTPUT
+          echo "files=\"${files[@]\"" >> $GITHUB_OUTPUT
+
+      - name: Create matrix
+        id: create-matrix
+        run: |
+          echo "matrix={\"family\":$(jq --compact-output --null-input '$ARGS.positional' --args -- ${{ steps.get-famillies.outputs.files }})}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
In the objective of getting more contribution, these changes create the family matrix at CI run time.

I will be easier for a non CI-friendly contributor to add a new family to project as they won't have to make change in the workflow files.

Updating the Test workflow was the opportunity to update the deprecated checkout action step.

