### PR TITLE
Replace an had oc check for CMake's version with a builtin

### DIFF
--- a/cmake/stm32_gcc.cmake
+++ b/cmake/stm32_gcc.cmake
@@ -1,7 +1,4 @@
-if(${CMAKE_VERSION} VERSION_LESS "3.16.0") 
-    message(WARNING "Current CMake version is ${CMAKE_VERSION}. stm32-cmake requires CMake 3.16 or greater")
-
-endif()
+cmake_minimum_required(VERSION 3.16)
 
 get_filename_component(STM32_CMAKE_DIR ${CMAKE_CURRENT_LIST_FILE} DIRECTORY)
 list(APPEND CMAKE_MODULE_PATH ${STM32_CMAKE_DIR})


### PR DESCRIPTION
`cmake_minimum_required` is the recommended way to do this check. Note that this will now make the configuration stop here rather than emiting a warning and panic later, on the line that actually require the version.