### PR TITLE
add CMSIS DSP library target to FindCMSIS.cmake

### DIFF
--- a/cmake/FindCMSIS.cmake
+++ b/cmake/FindCMSIS.cmake
@@ -313,6 +313,13 @@ foreach(COMP ${CMSIS_FIND_COMPONENTS_FAMILIES})
         set(CMSIS_${RTOS_COMP}_FOUND TRUE)
     endforeach()
 
+    if(NOT (TARGET CMSIS::STM32::${FAMILY}${CORE_C}::DSP}))
+        add_library(CMSIS::STM32::${FAMILY}${CORE_C}::DSP INTERFACE IMPORTED)
+        target_link_libraries(CMSIS::STM32::${FAMILY}${CORE_C}::DSP INTERFACE CMSIS::STM32::${FAMILY}${CORE_C})
+        target_link_directories(CMSIS::STM32::${FAMILY}${CORE_C}::DSP INTERFACE "${CMSIS_${FAMILY}${CORE_U}_CORE_PATH}/DSP/Lib/GCC/")
+        target_include_directories(CMSIS::STM32::${FAMILY}${CORE_C}::DSP INTERFACE "${CMSIS_${FAMILY}${CORE_U}_CORE_PATH}/DSP/Include")
+    endif()
+
     list(REMOVE_DUPLICATES CMSIS_INCLUDE_DIRS)
     list(REMOVE_DUPLICATES CMSIS_SOURCES)
 endforeach()


### PR DESCRIPTION
Add a target to the `FindCMSIS.cmake` that allows you to bring in the CMSIS DSP library for a given target. The targets end up looking like `CMSIS::STM32::H7::M7::DSP` as an example.

Let me know if there's anything you'd like me to tweak about this, otherwise it's a pretty simple change I think.