### PR TITLE
Add all currently active MCUs from STM32C0 family

### DIFF
--- a/cmake/stm32/c0.cmake
+++ b/cmake/stm32/c0.cmake
@@ -1,16 +1,32 @@
 set(STM32_C0_TYPES 
     C011xx
     C031xx
+    C051xx
+    C071xx
+    C091xx
+    C092xx
 )
 set(STM32_C0_TYPE_MATCH 
     "C011.[46]"
     "C031.[46]"
+    "C051.[68]"
+    "C071.[8B]"
+    "C091.[BC]"
+    "C092.[BC]"
 )
 set(STM32_C0_RAM_SIZES 
      6K
     12K
+    12K
+    24K
+    36K
+    30k
 )
 set(STM32_C0_CCRAM_SIZES 
+     0K
+     0K
+     0K
+     0K
      0K
      0K
 )
@@ -38,6 +54,47 @@ list(APPEND STM32_ALL_DEVICES
     C031G6
     C031K4
     C031K6
+    C051C6
+    C051C8
+    C051D8
+    C051F6
+    C051F8
+    C051G6
+    C051G8
+    C051K6
+    C051K8
+    C071C8
+    C071CB
+    C071F8
+    C071FB
+    C071G8
+    C071GB
+    C071K8
+    C071KB
+    C071R8
+    C071RB
+    C091CB
+    C091CC
+    C091EC
+    C091FB
+    C091FC
+    C091GB
+    C091GC
+    C091KB
+    C091KC
+    C091RB
+    C091RC
+    C092CB
+    C092CC
+    C092EC
+    C092FB
+    C092FC
+    C092GB
+    C092GC
+    C092KB
+    C092KC
+    C092RB
+    C092RC
 )
 
 list(APPEND STM32_SUPPORTED_FAMILIES_LONG_NAME


### PR DESCRIPTION
Verified by building and running a blinky on NUCLEO-C071RB 
