### PR TITLE
Fix LOAD Segment With RWX Permissions Warning

### DIFF
--- a/cmake/FindCMSIS.cmake
+++ b/cmake/FindCMSIS.cmake
@@ -88,6 +88,10 @@ function(cmsis_generate_default_linker_script FAMILY DEVICE CORE)
         stm32_get_memory_info(FAMILY ${FAMILY} DEVICE ${DEVICE} CORE ${CORE} HEAP SIZE HEAP_SIZE)
         stm32_get_memory_info(FAMILY ${FAMILY} DEVICE ${DEVICE} CORE ${CORE} STACK SIZE STACK_SIZE)
 
+        if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" AND ${CMAKE_C_COMPILER_VERSION} VERSION_GREATER_EQUAL "11.0.0")
+            set(LD_SCRIPT_FORCE_READONLY_SECTIONS TRUE)
+        endif()
+
         add_custom_command(OUTPUT "${OUTPUT_LD_FILE}"
             COMMAND ${CMAKE_COMMAND} 
                 -DFLASH_ORIGIN="${FLASH_ORIGIN}" 
@@ -101,6 +105,7 @@ function(cmsis_generate_default_linker_script FAMILY DEVICE CORE)
                 -DSTACK_SIZE="${STACK_SIZE}" 
                 -DHEAP_SIZE="${HEAP_SIZE}" 
                 -DLINKER_SCRIPT="${OUTPUT_LD_FILE}"
+                -DFORCE_READONLY_SECTIONS="${LD_SCRIPT_FORCE_READONLY_SECTIONS}"
                 -P "${STM32_CMAKE_DIR}/stm32/linker_ld.cmake"
         )
     endif()

--- a/cmake/stm32/linker_ld.cmake
+++ b/cmake/stm32/linker_ld.cmake
@@ -84,20 +84,20 @@ SECTIONS\n\
     __exidx_end = .;\n\
   } >FLASH\n\
 \n\
-  .preinit_array     :\n\
+  .preinit_array (READONLY)     :\n\
   {\n\
     PROVIDE_HIDDEN (__preinit_array_start = .);\n\
     KEEP (*(.preinit_array*))\n\
     PROVIDE_HIDDEN (__preinit_array_end = .);\n\
   } >FLASH\n\
-  .init_array :\n\
+  .init_array (READONLY) :\n\
   {\n\
     PROVIDE_HIDDEN (__init_array_start = .);\n\
     KEEP (*(SORT(.init_array.*)))\n\
     KEEP (*(.init_array*))\n\
     PROVIDE_HIDDEN (__init_array_end = .);\n\
   } >FLASH\n\
-  .fini_array :\n\
+  .fini_array (READONLY):\n\
   {\n\
     PROVIDE_HIDDEN (__fini_array_start = .);\n\
     KEEP (*(SORT(.fini_array.*)))\n\

--- a/cmake/stm32/linker_ld.cmake
+++ b/cmake/stm32/linker_ld.cmake
@@ -29,6 +29,10 @@ MB_MEM2 (NOLOAD)       : { _sMB_MEM2 = . ; *(MB_MEM2) ; _eMB_MEM2 = . ; } >RAM_S
     ")
 endif()
 
+if(FORCE_READONLY_SECTIONS)
+  set(READONLY "(READONLY)")
+endif()
+
 set(SCRIPT_TEXT 
 "ENTRY(Reset_Handler)\n\
 \n\
@@ -84,20 +88,20 @@ SECTIONS\n\
     __exidx_end = .;\n\
   } >FLASH\n\
 \n\
-  .preinit_array (READONLY)     :\n\
+  .preinit_array ${READONLY}     :\n\
   {\n\
     PROVIDE_HIDDEN (__preinit_array_start = .);\n\
     KEEP (*(.preinit_array*))\n\
     PROVIDE_HIDDEN (__preinit_array_end = .);\n\
   } >FLASH\n\
-  .init_array (READONLY) :\n\
+  .init_array ${READONLY} :\n\
   {\n\
     PROVIDE_HIDDEN (__init_array_start = .);\n\
     KEEP (*(SORT(.init_array.*)))\n\
     KEEP (*(.init_array*))\n\
     PROVIDE_HIDDEN (__init_array_end = .);\n\
   } >FLASH\n\
-  .fini_array (READONLY):\n\
+  .fini_array ${READONLY}:\n\
   {\n\
     PROVIDE_HIDDEN (__fini_array_start = .);\n\
     KEEP (*(SORT(.fini_array.*)))\n\


### PR DESCRIPTION
Starting with GCC11 LD shows the following error message when using the autogenerated linker script:

```
arm-none-eabi/bin/ld: warning: testi.elf has a LOAD segment with RWX permissions
```

This happens because some sections that go into the FLASH memory have read-write access permissions which in turn forces FLASH to become RWX.

Here is a relevant StackOverflow thread: https://stackoverflow.com/questions/73429929/gnu-linker-elf-has-a-load-segment-with-rwx-permissions-embedded-arm-project

ST suggest to change sections like

```
.preinit_array :
 {
   …
 } >FLASH
```

to

```
 .preinit_array (READONLY) :
 {
   …
 } >FLASH
```

Reference: https://wiki.st.com/stm32mcu/wiki/STM32CubeIDE:STM32CubeIDE_errata_1.15.x#General_issues
See 169316

This pull request adds the (READONLY) attribute to the corresponding sections if GCC version >= 11.